### PR TITLE
Add code to perform centroiding of the data

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.R]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[Makefile]
+indent_style = tab
+
+[.travis.yml]
+indent_style = space
+indent_size = 2
+
+[*.qmd]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.Rmd]
+indent_style = space
+indent_size = 4
+max_line_length = 80

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+local_data/*
+.Rproj.user
+data/phenodata.txt
+phenodata.txt
+data/*
+chris_scanning*
+*.RData
+*.png
+*.html
+*.pdf
+images/

--- a/centroiding.qmd
+++ b/centroiding.qmd
@@ -1,0 +1,123 @@
+---
+title: "Centroiding of the profile-mode LC-MS/MS data"
+format: html
+tbl-cap-location: bottom
+editor: visual
+date: 'Compiled: `r format(Sys.Date(), "%B %d, %Y")`'
+---
+
+# Introduction
+
+This document defines and describes the centroiding of the profile-mode FTMS
+LC-MS/MS data. The fragment spectra (MS1-MS4) seem all to be in centroid mode,
+while the MS1 data is not. So, we need to centroid specifically the MS1 spectra.
+
+# Data import and centroiding
+
+We use the *Spectra* package, in particular its `pickPeaks()` function to
+perform the centroiding. We perform the analysis separately for each original
+mzXML file and export the data directly to a file in mzML format.
+
+```{r}
+#| message: false
+
+#' Load required libraries
+library(Spectra)
+
+#' Define the paths to the original mzXML files with the profile-mode data
+#' and the path where we want to export the centroided mzML data.
+MZXML_PATH <- "data/mzXML"
+MZML_PATH <- "data/mzML"
+
+#' List all files
+fls <- dir(MZXML_PATH, full.name = TRUE)
+
+```
+
+We first inspect the profile-mode data and dry-run the centroiding on one
+spectrum.
+
+```{r}
+a <- filterMsLevel(Spectra(fls[1]), 1L)[4]
+
+par(mfrow = c(1, 2))
+plotSpectra(a)
+grid()
+filterMzRange(a, c(372.5, 373.5)) |>
+    plotSpectra()
+grid()
+```
+
+In profile-mode data, each mass peak is represented by a distribution of
+signal. The centroiding will select a single, representative, mass peak for each
+such distribution. The algorithm we apply first estimates local maxima in each
+MS1 spectrum and for each it reports the peak with the maximum intensity. We
+further *refine* the m/z of the reported mass peak using an intensity-weighted
+average of the mass peak and the neighboring 2 peaks (`k = 2L`), if their
+intensity is at least 1/3 (`threshold = 0.33`) of the reported mass peak.
+
+
+```{r}
+
+a_c <- pickPeaks(a, halfWindowSize = 10L, k = 2L, threshold = 0.33)
+
+par(mfrow = c(2, 2))
+plotSpectra(a)
+grid()
+plotSpectra(a_c)
+grid()
+filterMzRange(a, mz = c(372.5, 373.5)) |>
+    plotSpectra()
+grid()
+filterMzRange(a_c, mz = c(372.5, 373.5)) |>
+    plotSpectra()
+grid()
+
+```
+
+We plot the signal also for another peak:
+
+```{r}
+par(mfrow = c(1, 2))
+filterMzRange(a, mz = c(200.15, 200.2)) |>
+    plotSpectra()
+grid()
+filterMzRange(a_c, mz = c(200.15, 200.2)) |>
+    plotSpectra()
+grid()
+```
+
+While we reduced the profile-mode peaks to single mass peaks there is still some
+remains of the fast fourier transform artefact present, especially for the first
+example.
+
+We proceed now and centroid all data files with the settings above.
+
+```{r}
+if (!dir.exists(MZML_PATH))
+    dir.create(MZML_PATH, recursize = TRUE)
+
+for (f in fls) {
+    a <- Spectra(f)
+    fn <- file.path(MZML_PATH, sub("mzXML$", "mzML", basename(f)))
+    a <- pickPeaks(a, halfWindowSize = 10L, k = 2L, threshold = 0.33)
+    export(a, backend = MsBackendMzR(), file = fn,
+           format = "mzML", copy = TRUE)
+}
+
+b <- Spectra(fn)
+all(centroided(b))
+
+```
+
+# Questions and notes
+
+- [ ] There seems to be still some fourier transform artefact present in the
+      data after the centroiding. Maybe we could/should use another software for
+      the centroiding? Maybe the original Thermo software?
+
+# Session information
+
+```{r}
+sessionInfo()
+```


### PR DESCRIPTION
This PR adds a new centroiding.qmd file to perform the centroiding of the profile-mode MS1 data.

Apparently, only the MS1 data is in profile mode - the MSn data is reported to be centroided (although I did not check if that's true). So, the code assumes that the mzXML files are located in a folder "data/mzXML" (path can be configured within the qmd file) and processes each of these mzXML files separately, centroiding the MS1 spectra and exporting the data to a file with the same file name (in mzML format) to a folder "data/mzML" (can also be configured within the qmd file).

Some things we might eventually want to discuss later is if we're OK with the "fourier transform artefacts" (something common to FTMS data) that are still in the MS1 data after centroiding (although less pronounced). I would suggest we check later if this has an impact/problem on the data.