### PR TITLE
The modified Fms_filtering.qmd file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This folder contains the following files:
 
 <!-- -->
 
--   " ftms_analysis.qmd" : where we upload and analyse the data with the xcms treatment.
+-   " ftms_preprocessing.qmd" : where we upload and analyse the data with the xcms treatment.
 
--   "adding_to_the_RDynlib_library.qmd" : in this file we filtered the ftms data and we kept just one tree per feature and we load the resulting object as "ftms_one_tree".
+-   "ftms_filtering.qmd" : in this file we filtered the ftms data and we kept just one tree per feature and we load the resulting object as "ftms_one_tree".
 
     **The execution order:**
 
     1.  " centroiding.qmd"
-    2.  " ftms_analysis.qmd"
-    3.  "adding_to_the_RDynlib_library.qmd"
+    2.  " ftms_preprocessing.qmd"
+    3.  "ftms_filtering.qmd"

--- a/README.md
+++ b/README.md
@@ -10,17 +10,6 @@ This folder contains the following files:
 - [ftms_preprocessing.qmd](ftms_preprocessing.qmd) : where we load and analyse
   the data with the *xcms* package.
 
-
--   " ftms_preprocessing.qmd" : where we upload and analyse the data with the xcms treatment.
-
--   "ftms_filtering.qmd" : in this file we filtered the ftms data and we kept just one tree per feature and we load the resulting object as "ftms_one_tree".
-
-    **The execution order:**
-
-    1.  " centroiding.qmd"
-    2.  " ftms_preprocessing.qmd"
-    3.  "ftms_filtering.qmd"
-
 - [ftms_filtering.qmd](ftms_filtering.qmd): in this file we filter the ftms data
   to keep one tree per feature.
 

--- a/centroiding.qmd
+++ b/centroiding.qmd
@@ -12,18 +12,28 @@ This document defines and describes the centroiding of the profile-mode FTMS LC-
 
 # Data import and centroiding
 
-We use the *Spectra* package, in particular its `pickPeaks()` function to perform the centroiding. We perform the analysis separately for each original mzXML file and export the data directly to a file in mzML format.
+We first load all required R packages for the analysis in this document.
 
 ```{r}
 #| message: false
 
 #' Load required libraries
 library(Spectra)
+library(MsExperiment)
+library(readxl)
+library(dplyr)
+library(readr)
+library(purrr)
+```
 
+We use the *Spectra* package, in particular its `pickPeaks()` function to perform the centroiding. We perform the analysis separately for each original mzXML file and export the data directly to a file in mzML format.
+
+```{r}
 #' Define the paths to the original mzXML files with the profile-mode data
 #' and the path where we want to export the centroided mzML data.
-MZXML_PATH <- "data/mzXML"
-MZML_PATH <- "data/mzML"
+pth <- getwd()
+MZXML_PATH <- file.path(pth,"data","mzXML")
+MZML_PATH <- file.path(pth,"data","mzML")
 
 #' List all files
 fls <- dir(MZXML_PATH, full.name = TRUE)
@@ -81,7 +91,7 @@ We proceed now and centroid all data files with the settings above.
 
 ```{r}
 if (!dir.exists(MZML_PATH))
-    dir.create(MZML_PATH, recursize = TRUE)
+    dir.create(MZML_PATH, recursive = TRUE)
 
 for (f in fls) {
     a <- Spectra(f)
@@ -99,10 +109,10 @@ all.equal(a$scanIndex, b$scanIndex)
 ```
 
 ```{r}
-sample_data_ftms <- read_xlsx("C:/Users/amentag/Desktop/Rcodes/RDynLib_ftms/data/ftms_data_files.xlsx") |>
+sample_data_ftms <- read_xlsx(file.path(pth,"data","sample_data","ftms_data_files.xlsx")) |>
     as.data.frame()
-file <- "C:/Users/amentag/Desktop/Rcodes/RDynLib_ftms/data/mzML/"
-ftms <- readMsExperiment(paste0(file, sample_data_ftms$data_file),
+
+ftms <- readMsExperiment(file.path(MZML_PATH, sample_data_ftms$data_file),
                          sampleData = sample_data_ftms)
 ftms
 ```
@@ -113,20 +123,20 @@ spectraData(s)
 ```
 
 ```{r}
-library(dplyr)
-library(readr)
-library(purrr)
+# Create the read_csv_safely() function to safely read a delimited text file (CSV or TSV) into a data frame.
+# The function tries to use readr::read_delim() for speed and robustness,
+# and falls back to base::read.csv() if an error occurs.
 read_csv_safely <- function(file_path, sep = "\t", quote = "\"", header = TRUE, col_types = NULL) {
   if (!file.exists(file_path)) {
-    stop(paste("Le fichier n'existe pas :", file_path))
+    stop(paste("The file does not exist:", file_path))
   }
   
   tryCatch({
     data <- read_delim(file_path, delim = sep, quote = quote, col_names = header, col_types = col_types)
     return(as.data.frame(data))  
   }, error = function(e) {
-    message("Erreur lors de la lecture avec read_delim : ", e$message)
-    message("Essai avec read.csv...")
+    message("Error while reading with read_delim: ", e$message)
+    message("Trying read.csv...")
     data <- read.csv(file_path, sep = sep, quote = quote, header = header, stringsAsFactors = FALSE)
     return(as.data.frame(data))  
   })
@@ -164,7 +174,7 @@ head(ms2_mismatched)
 
 # Questions and notes
 
--   [ ] There seems to be still some fourier transform artefact present in the data after the centroiding. Maybe we could/should use another software for the centroiding? Maybe the original Thermo software?
+-   [ ] There seems to be still some fourier transform artefact present in the data after the centroiding. Maybe we could/should use another software for the centroiding? Maybe the original Thermo software? -\>For future analyses we can record also the MS1 data directly in centroid mode.
 
 # Session information
 

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -5,20 +5,25 @@ format:
     toc: true
     self-contained: true
 author: "Ahlam Mentag, Johannes Rainer"
+editor: 
+  markdown: 
+    wrap: 72
 ---
 
 # Introduction
 
-This Quarto document presents the analysis of FTMS flaxseed data for selecting
-one representative tree per feature. Preprocessing and feature definition was
-performed in [ftms_preprocessing.qmd](ftms_preprocessing.qmd).
+This Quarto document presents the analysis of FTMS flaxseed data for
+selecting one representative tree per feature. Preprocessing and feature
+definition was performed in
+[ftms_preprocessing.qmd](ftms_preprocessing.qmd).
 
 # Data import
 
 Loading all required libraries and importing the results from the data
-prepocessing.
+preprocessing.
 
 ```{r}
+#| message: false
 library(dplyr)
 library(tidyr)
 library(xcms)
@@ -38,8 +43,16 @@ load(file.path(pth, "data", "ftms.RData"))
 class(ftms)
 ```
 
-Next, we use `featureSpectra()"` to extract all MS2 spectra for each feature
-from `ftms` object.
+# Explore MS2 spectra associated to features
+
+Next, we use `xcms::featureSpectra()` to extract all MS2 spectra for
+each feature from `ftms` object.
+
+> The `xcms::featureSpectra()` function returns a `Spectra` object.
+>
+> When using `msLevel = 2`, the resulting `Spectra` object contains all
+> MS2 spectra whose retention time and precursor m/z fall within the
+> ranges of any chromatographic peak of a feature.
 
 ```{r}
 ms2 <- featureSpectra(ftms, msLevel = 2)
@@ -48,8 +61,8 @@ msLevel(ms2) |>
   table()
 ```
 
-it returns 1679 MS level 2 spectra. The total number of features for which an
-MS2 spectrum was identified is:
+it returns 1679 MS level 2 spectra. The total number of features for
+which an MS2 spectrum was identified is:
 
 ```{r}
 length(unique(ms2$feature_id))
@@ -62,11 +75,63 @@ s <- spectra(ftms)
 table(msLevel(s))
 ```
 
+In total, there were 20804 MS2 spectra. This means that 92% of the MS2
+spectra ((20804-1679)\*100/20804) could not be assigned to any
+chromatographic peak.
+
+MS2 spectra are assigned to chromatographic peaks for which they lay
+within the mz and rt limits. Therefore, they can be assigned to more
+than one chromatographic feature. In the below code we explore, for each
+sample (dataOrigin), how many MS2 spectra are assigned to more than one
+feature. This is reflected in multiple appearances of the same MS2
+spectra (with the same scanIndex).
+
+```{r}
+scanIndex.per.ori <- split(ms2$scanIndex, ms2$dataOrigin)
+lapply(scanIndex.per.ori, function(x) any(duplicated(x)))
+lapply(scanIndex.per.ori, function(x) x[duplicated(x)])
+```
+
+Many MS2 spectra are indeed assigned to multiple features. We have a
+closer look at sample s1r3:
+
+```{r}
+ms2.per.ori <- split(ms2, ms2$dataOrigin)
+s1r3 <- ms2.per.ori[[3]]                     
+spdat  <-spectraData(s1r3)
+spdat$scanIndex[duplicated(spdat$scanIndex)]
+```
+
+In sample s1r3, the spectra with ScanIndex 381, 1540, and 1814 are
+duplicated in the ms2 Spectra object, because they are assigned to two
+different features.
+
+```{r}
+spdat[spdat$scanIndex == 1814,]
+spdat[spdat$scanIndex == 1540,]
+spdat[spdat$scanIndex == 381,]
+spdat_si381 <- spdat[spdat$scanIndex == 381,]
+spdat_si381$rtime - spdat_si381$feature_rtmed
+```
+
+ScanIndex 1814 is assigned to two FeatureIDs: FT3146 and FT3149
+ScanIndex 1540 is assigned to two FeatureIDs: FT0870 and FT0871
+ScanIndex 381 is assigned to two FeatureIDs: FT0268 and FT0270 and their
+retention time is 30 seconds different. The retention time of the
+spectrum is closer to rtmed of feature FT0268
+
+But the precursor could indeed be a mixture of both features.
+
+# Extract all MS2-MSn spectra associated to features
+
 We next define a function to extract the full MSn tree for features.
-This function takes an `XcmsExperiment` object as input, extracts the MS2
-spectra using `featureSpectra()` function, and then retrieves all MS3 (and
-subsequently MS4 spectra) for all these MS2 spectra using the *precScanNum*
-spectra variable.
+This function takes an `XcmsExperiment` object as input, extracts the
+MS2 spectra using `xcms::featureSpectra()` function, and then retrieves
+all MS3 (and subsequently MS4 spectra) for all these MS2 spectra using
+the *precScanNum* spectra variable. The `ftms_all_levels` function
+returns a combined `Spectra` object containing all MS2, MS3, and MS4
+spectra, with each spectrum linked to a feature via a propagated
+`feature_id` from the originally matched MS2 spectrum.
 
 ```{r}
 ftms_all_levels <- function(ftms) {
@@ -128,16 +193,31 @@ a
 #' split by dataOrigin
 al <- split(a, a$dataOrigin)
 
-spectraData(al[[1]], columns = c("msLevel", "acquisitionNum", "precScanNum")) |>
+spectraData(al[[1]], columns = c("dataOrigin", "msLevel", "acquisitionNum", "precScanNum", "precursorMz")) |>
     as.data.frame()
-#' Looks correct. Let's see what filterPrecursorScan does
+
+#' Looks correct. To feature FT0649, in sample S1R1, there are 4 MS2 spectra linked, which correctly have all the same precursorMz = 285. The four MS2 spectra have acquisitionNum 3851, 3870, 3905, and 3919.
+#' Let's see what filterPrecursorScan does
 
 filterPrecursorScan(al[[1]], 3851)
 filterPrecursorScan(al[[1]], 3870)
 filterPrecursorScan(al[[1]], 3905)
 filterPrecursorScan(al[[1]], 3919)
+
+spectraData(filterPrecursorScan(al[[1]], 3851), columns = c("msLevel", "acquisitionNum", "precScanNum", "precursorMz"))|>as.data.frame()
+spectraData(filterPrecursorScan(al[[1]], 3852), columns = c("msLevel", "acquisitionNum", "precScanNum", "precursorMz"))|>as.data.frame()
+spectraData(filterPrecursorScan(al[[1]], 3854), columns = c("msLevel", "acquisitionNum", "precScanNum", "precursorMz"))|>as.data.frame()
 #' Seems to be OK
 ```
+
+The above result shows that `filterPrecursorScan()` extracts the full
+MSn tree: it includes spectra of levels MS2 or higher
+
+-   whose acquisition number itself matches the given Precursor scan
+    number
+-   AND whose precScanNum matches the given Precursor scan number
+-   AND higher level spectra that depend on it
+-   AND lower level spectra that gave rise to it
 
 The number of spectra from different MS levels is shown below:
 
@@ -145,9 +225,43 @@ The number of spectra from different MS levels is shown below:
 table(msLevel(ftms_msn_tree))
 ```
 
-We next need to group all MSn spectra from one fragment tree together.
-The function below creates an *MSntreeID* column grouping related scans into
-fragmentation trees based on their parent-child relationships.
+We check MSn trees propagated from MS2 spectra that were assigned to
+multiple chromatographic features.
+
+```{r}
+al <- split(ftms_msn_tree, ftms_msn_tree$dataOrigin)
+S1R3 <- al[[3]]
+spdat  <-spectraData(S1R3)
+spdat[spdat$scanIndex %in% 1815:1817,]
+spdat[spdat$feature_id %in% c("FT3146","FT3149"),]
+spdat[spdat$feature_id %in% c("FT0268","FT0270"),]
+```
+
+In ftms_msn_tree, MS2 that are assigned to multiple features, and all
+dependent spectra (MS3, and MS4), are present multiple times. For
+example: MS2_scandindex381 gives rise to MS3_scandindex382 and
+MS3_scandindex383. Because MS2_scandindex381 was assigned to both
+feature FT0268 and FT0270, these spectra are duplicated in
+ftms_msn_tree: with feature_id = FT0268 and with feature_id = FT0270.
+
+# Grouping MSn spectra into fragmentation trees
+
+We next need to group all MSn spectra from one fragmentation tree
+together.
+
+The function `assign_msntree_id()` will:
+
+-   Take a `Spectra` object `x` containing MS2–MSn spectra\
+-   Assign tree IDs to each spectrum in `x`, based on precursor
+    relationships within each sample (`dataOrigin`)\
+-   Ensure that MS2 spectra always start a new tree, and that MS3/MS4
+    spectra inherit the tree ID from their parent
+-   Return a vector of integers, the same length as the number of
+    spectra in `x`, where each integer represents the fragmentation tree
+    ID the spectrum belongs to
+
+The output of the `assign_msntree_id()` function is then added to the
+`Spectra` object as a new spectra variable *MSntreeID*.
 
 ```{r}
 
@@ -221,6 +335,9 @@ ftms_msn_tree$MSntreeID |>
 There is apparently (at least) one tree with 7 spectra. Extracting this
 particular MSn tree.
 
+We will check MSntreeID of spectra that were assigned to multiple
+chromatographic features.
+
 ```{r}
 max_index <- ftms_msn_tree$MSntreeID |>
     table() |>
@@ -231,11 +348,220 @@ max_tree <- ftms_msn_tree[ftms_msn_tree$MSntreeID == max_index]
 max_tree$rtime
 max_tree$msLevel
 max_tree$precScanNum
+max_tree$scanIndex
+max_tree$acquisitionNum
+max_tree$dataOrigin
+max_tree$feature_id
+max_tree$MSntreeID
+```
+
+The MSntree with maximum number of spectra corresponds to the tree,
+within dataOrigin S1R3, depending on MS2 with ScanIndex 1814 which was
+assigned to two FeatureIDs: FT3146 and FT3149 Within dataOrigin S1R3,
+scanIndex 1815 (MS3), 1816 (MS3), and 1817 (MS4) are assigned to two
+different features: FT3146, and FT3149.
+
+```{r}
+al <- split(ftms_msn_tree, ftms_msn_tree$dataOrigin)
+S1R3 <- al[[3]]
+double_tree <- S1R3[S1R3$feature_id %in% c("FT3146","FT3149")]
+
+double_tree$rtime
+double_tree$msLevel
+double_tree$precScanNum
+double_tree$scanIndex
+double_tree$feature_id
+double_tree$MSntreeID
+```
+
+Now we check the MSntree corresponding to dataOrigin S1R3 - ScanIndex
+381, which was assigned to two FeatureIDs: FT0268 and FT0270
+
+```{r}
+al <- split(ftms_msn_tree, ftms_msn_tree$dataOrigin)
+S1R3 <- al[[3]]
+double_tree <- S1R3[S1R3$feature_id %in% c("FT0268","FT0270")]
+
+double_tree$rtime
+double_tree$msLevel
+double_tree$precScanNum
+double_tree$scanIndex
+double_tree$feature_id
+double_tree$MSntreeID
+```
+
+Observation of the duplicated spectral trees that were assigned to two
+features (the tree assigned to FT0268 and FT0270, and the trees assigned
+to FT3146 and FT3149) shows a mistake in the assembly of the MSntree
+groups, resulting from forcing MS2 spectra to start a new tree:
+
+Below, spectra are named by their scanIndex: 
+MSntreeID 334 comprises:
+381 (MS2 - FT0268), 382 (MS3 - FT0268), 383 (MS3 - FT0268) , **382 (MS3 -
+FT0270)**, **383 (MS3 - FT0270)**
+
+MSntreeID 336 comprises:
+**381 (MS2 - FT0270)**
+
+MSntreeID 335 comprises:
+324 (MS2 - FT0270), 326 (MS3 - FT0270)
+
+MSntreeID 433 comprises:
+1814 (MS2 - FT3146), 1815 (MS3 - FT3146), 1816 (MS3 - FT3146) , 1817 (MS4 - FT3146), **1815 (MS3 -
+FT3149)**, **1816 (MS3 - FT3149)**, **1817 (MS4 - FT3149)
+
+MSntree 444 comprises:
+**1814 (MS2 - FT3149)**
+
+**In both cases, the duplicated spectral tree that was assigned to another chromatographic feature, has been split: the MS2 spectrum was assigned to a new MSntree, whereas the higher level spectra were associated as doubles to the MSntree associated with the first chromatographic feature.**
+
+Below, we have a closer look at these two features.
+
+```{r}
+feat <- c("FT3146","FT3149")
+feat_idx <- ms2sp$feature_id %in% feat
+ms2sp[feat_idx,]
+```
+
+Features FT3146, and FT3149 have almost exactly the same mzmin and
+mzmax, but 10 seconds difference in rtmed. We have a look at EICs for
+these features.
+
+```{r}
+fdefs <- featureDefinitions(ftms)
+feature_ids <- rownames(fdefs) 
+#FT3146
+fid <- "FT3146"
+finfo <- fdefs[fid, ]
+eic1 <- chromatogram(
+  ftms,
+  mz = c(finfo$mzmin, finfo$mzmax),
+  rt = c(1000, 1100)
+)
+
+#FT3149
+fid <- "FT3149"
+finfo <- fdefs[fid, ]
+eic2 <- chromatogram(
+  ftms,
+  mz = c(finfo$mzmin, finfo$mzmax),
+  rt = c(1000, 1100)
+)
+
+par(mfrow = c(2, 1))
+plot(eic1)
+plot(eic2)
 
 ```
 
-This tree has thus several MS3 and MS4 spectra.
 
+```{r}
+fdefs <- featureDefinitions(ftms)
+feature_ids <- rownames(fdefs) 
+#FT0268
+fid <- "FT0268"
+finfo <- fdefs[fid, ]
+eic1 <- chromatogram(
+  ftms,
+  mz = c(finfo$mzmin, finfo$mzmax),
+  rt = c(150, 250)
+)
+
+#FT0270
+fid <- "FT0270"
+finfo <- fdefs[fid, ]
+eic2 <- chromatogram(
+  ftms,
+  mz = c(finfo$mzmin, finfo$mzmax),
+  rt = c(150, 250)
+)
+
+par(mfrow = c(2, 1))
+plot(eic1)
+plot(eic2)
+
+```
+
+# What to do with spectra assigned to multiple features?
+The chromatographic peaks of these two features are quite similar. Maybe we could merge the two features in case spectra are assigned to both. 
+We could also change the method of `featureSpectra()` to assign MS2 spectra to the single chromatographic feature that is closest in retention time (and within an m/z range) ==> each MSntree will be assigned to a single feature.
+In reality, these are probably two different isomers and the spectra are most probably derived from a mixture. 
+If we want to keep duplicated spectral trees assigned to different features, we need to modify the function `assign_msntree_id()`.
+When selecting an MSntree to add to the database, it is important to take the purity of the precursor into account. If an MS2 falls within mz and rt range of two features, it maybe not pure and priority could be given to spectra that can only be assigned to a single feature.
+
+# Merging two features in an XcmsExperiment object
+The code below merges two specific features in an XcmsExperiment object.
+Applying `ftms_all_levels()` and `assign_msntree_id`to the new XcmsExperiment object did not solve the problem, and the code needs to be optimized IF we decide that we want to go this way (merging peaks).
+
+```{r}
+# Manually merging two features in an XcmsExperiment object
+# Extract feature definitions, chromPeaks, and Sample Data
+fdefs <- featureDefinitions(ftms)
+cp <- chromPeaks(ftms)
+sdata <- sampleData(ftms)
+
+# Extract the two feature IDs to merge
+fid1 <- "FT3146"
+fid2 <- "FT3149"
+
+f1 <- fdefs[fid1, ]
+f2 <- fdefs[fid2, ]
+
+# Merge the peak indices
+merged_peakidx <- unique(c(unlist(f1$peakidx), unlist(f2$peakidx)))
+
+# Get sample indices for merged peaks
+sample_indices <- cp[merged_peakidx, "sample"]
+
+# Determine sample group membership
+sample_group_membership <- sdata$sample_id[sample_indices]
+sample_counts <- table(factor(sample_group_membership, levels = unique(sample_groups)))
+
+# Construct merged feature row
+merged_feature <- DataFrame(
+  mzmed = mean(c(f1$mzmed, f2$mzmed)),
+  mzmin = min(f1$mzmin, f2$mzmin),
+  mzmax = max(f1$mzmax, f2$mzmax),
+  rtmed = mean(c(f1$rtmed, f2$rtmed)),
+  rtmin = min(f1$rtmin, f2$rtmin),
+  rtmax = max(f1$rtmax, f2$rtmax),
+  npeaks = as.numeric(length(unique(sample_names))),
+  peakidx = I(list(merged_peakidx)),
+  ms_level = unique(c(f1$ms_level, f2$ms_level))
+)
+
+# Add per-group sample columns
+group_cols <- colnames(fdefs)[colnames(fdefs) %in% names(sample_counts)]
+for (grp in group_cols) {
+  merged_feature[[grp]] <- as.numeric(sample_counts[[grp]])
+}
+merged_feature <- merged_feature[, colnames(fdefs)]
+
+# Replace original features with merged one
+fdefs_new <- fdefs[!(rownames(fdefs) %in% c(fid1, fid2)), ]
+fdefs_new <- rbind(fdefs_new, as.data.frame(merged_feature))
+rownames(fdefs_new)[nrow(fdefs_new)] <- paste0(fid1, "_", fid2, "_merged")
+
+# Update the XcmsExperiment object
+featureDefinitions(ftms) <- fdefs_new
+
+
+```
+
+TODO: After merging two features: in spectraData of ftms_msn_tree
+(sampleOrigin S1R3), scanIndex 1815, 1816, 1817 are double. One should
+be removed.
+
+```{r}
+al <- split(ftms_msn_tree, ftms_msn_tree$dataOrigin)
+S1R3 <- al[[3]]
+spdat  <-spectraData(S1R3)
+spdat[spdat$scanIndex %in% 1815:1817,]
+
+```
+
+TODO: create code to check if MSn_trees are assigned to more than one
+feature
 
 ```{r}
 ## we stored the tree ids and the msLevels to a dataframe
@@ -253,12 +579,13 @@ table(max_level_per_tree$max_level)
 
 ```
 
-The number of trees that go up to MS2 level is : 415
-The number of trees that go up to MS3 level is : 338
-The number of trees that go up to MS4 level is : 926
+The number of trees that go up to MS2 level is : 415 The number of trees
+that go up to MS3 level is : 338 The number of trees that go up to MS4
+level is : 926
 
-Next we select one most representative tree per feature based on the longest one
-and if we have many, we select one tree with the highest MS2 precursor intensity
+Next we select one most representative tree per feature based on the
+longest one and if we have many, we select one tree with the highest MS2
+precursor intensity
 
 ```{r}
 
@@ -302,27 +629,25 @@ msLevel(ftms_one_tree) |> table()
 
 ```
 
-after selecting one representative tree per feature we have now:
-MS2 : 437, MS3 : 523, MS4 : 262
+after selecting one representative tree per feature we have now: MS2 :
+437, MS3 : 523, MS4 : 262
 
-
-Finally we verify if the number of unique features corresponds to the number of
-unique MSntreeID to ensure that we have one tree per feature.
+Finally we verify if the number of unique features corresponds to the
+number of unique MSntreeID to ensure that we have one tree per feature.
 
 ```{r}
 length(unique(ftms_one_tree$feature_id))
 ```
 
-
 ```{r}
 length(unique(ftms_one_tree$MSntreeID))
 ```
 
-we have 437 unique feature and unique MSntreeID, That's mean that we have for
-each feature one representative tree.
-
+we have 437 unique feature and unique MSntreeID, That's mean that we
+have for each feature one representative tree.
 
 Now we save the resulting ftms spectra object to a local directory.
+
 ```{r}
 save(ftms_one_tree, file = file.path(pth, "data", "ftms_one_tree.RData"))
 ```

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -39,7 +39,7 @@ First we load the `XcmsExperiment` ftms object
 
 ```{r}
 
-load(file.path(pth, "data", "ftms.RData"))
+load(file.path(pth, "data", "ftms_sh.RData"))
 class(ftms)
 ```
 
@@ -60,12 +60,17 @@ ms2 <- featureSpectra(ftms, msLevel = 2)
 msLevel(ms2) |>
   table()
 ```
+```{r}
+spectraData(ms2)
+```
 
-it returns 1679 MS level 2 spectra. The total number of features for
+
+it returns 2755 MS level 2 spectra. The total number of features for
 which an MS2 spectrum was identified is:
 
 ```{r}
 length(unique(ms2$feature_id))
+length(ms2$feature_id)
 ```
 
 Here we print the initial number of MSLevels.
@@ -75,24 +80,99 @@ s <- spectra(ftms)
 table(msLevel(s))
 ```
 
-In total, there were 20804 MS2 spectra. This means that 92% of the MS2
+In total, there were 20804 MS2 spectra. This means that 86% of the MS2
 spectra ((20804-1679)\*100/20804) could not be assigned to any
 chromatographic peak.
 
-MS2 spectra are assigned to chromatographic peaks for which they lay
-within the mz and rt limits. Therefore, they can be assigned to more
-than one chromatographic feature. In the below code we explore, for each
-sample (dataOrigin), how many MS2 spectra are assigned to more than one
-feature. This is reflected in multiple appearances of the same MS2
-spectra (with the same scanIndex).
+The percentage of features with at least one MS2:
+```{r}
+# Total number of features in ftms
+n_total_features <- nrow(featureDefinitions(ftms))
 
+# Features with ≥1 MS2 (those returned by featureSpectra)
+n_features_with_ms2 <- length(ms2)
+
+# Percentage
+perc_features_with_ms2 <- (n_features_with_ms2 / n_total_features) * 100
+perc_features_with_ms2
+
+
+
+```
+The percentage of features with at least one MS2 is 49%
+
+the percentage of MS2 spectra that are assigned to a feature
+
+```{r}
+# Total number of MS2 spectra in the dataset
+n_total_ms2 <- sum(msLevel(s) == 2)
+
+# Number of MS2 spectra assigned to features
+n_assigned_ms2 <- sum(lengths(ms2))
+
+# Percentage assigned
+perc_ms2_assigned <- (n_assigned_ms2 / n_total_ms2) * 100
+perc_ms2_assigned
+
+```
+the percentage of MS2 spectra that are assigned to a feature is 15%
+
+Now we will keep just one MS2 the closest in retention time if there is more
+than one MS2 spectra linked to the same feature.
+First we select the duplicated MS2 spectra for that we select those with the
+same dataOrigin, same acquisitionNum, and different feature_id. and from those 
+duplicated MS2 spectra we keep just one with a retention time close to the
+retention time of the feature
+
+```{r}
+
+select_unique_MS2 <- function(ms2, ftms){
+  sp <- spectraData(ms2)
+  
+  #Create indices for the duplicated groupes (i.e: dataOrigine + acquisitionNum)
+  sp$groupID <- paste0(sp$dataOrigine, "_", sp$acquisitionNum)
+  
+  #Group Indices by groupID
+  groups <- split(1:nrow(sp), sp$groupID)
+  
+  #List to store indices that we will keep
+  keep_indices <- unlist(
+    lapply(groups, function(idx){
+      #keep just the indices that have different feature_id
+      if(length(unique(sp$feature_id[idx])) > 1){
+        #Calclate the difference between the RT of each MS2 spectra with
+        #the RT of the feature that is assigned to 
+        rt_diff <- abs(rtime(ms2)[idx] - featureDefinitions(ftms)[sp$feature_id[idx], "rtmed"])
+        
+        #keep the index with the smallest RT difference
+        idx[which.min(rt_diff)]
+      }else{
+        idx
+      }
+      })
+  )
+  
+  ms2_unique <- ms2[keep_indices]
+  
+  return(ms2_unique)
+}
+
+ms2 <- select_unique_MS2(ms2, ftms)
+spectraData(ms2)
+
+```
+
+
+In the below code we explore, for each
+sample (dataOrigin), if it still some MS2 spectra assigned to more than one
+feature. 
 ```{r}
 scanIndex.per.ori <- split(ms2$scanIndex, ms2$dataOrigin)
 lapply(scanIndex.per.ori, function(x) any(duplicated(x)))
 lapply(scanIndex.per.ori, function(x) x[duplicated(x)])
 ```
 
-Many MS2 spectra are indeed assigned to multiple features. We have a
+No MS2 spectra are indeed assigned to multiple features. We have a
 closer look at sample s1r3:
 
 ```{r}
@@ -102,9 +182,11 @@ spdat  <-spectraData(s1r3)
 spdat$scanIndex[duplicated(spdat$scanIndex)]
 ```
 
-In sample s1r3, the spectra with ScanIndex 381, 1540, and 1814 are
-duplicated in the ms2 Spectra object, because they are assigned to two
-different features.
+```{r}
+spdat[spdat$scanIndex == 381, ]
+```
+
+In sample s1r3, spectra are not assigned to a unique feature.
 
 ```{r}
 spdat[spdat$scanIndex == 1814,]
@@ -114,13 +196,7 @@ spdat_si381 <- spdat[spdat$scanIndex == 381,]
 spdat_si381$rtime - spdat_si381$feature_rtmed
 ```
 
-ScanIndex 1814 is assigned to two FeatureIDs: FT3146 and FT3149
-ScanIndex 1540 is assigned to two FeatureIDs: FT0870 and FT0871
-ScanIndex 381 is assigned to two FeatureIDs: FT0268 and FT0270 and their
-retention time is 30 seconds different. The retention time of the
-spectrum is closer to rtmed of feature FT0268
 
-But the precursor could indeed be a mixture of both features.
 
 # Extract all MS2-MSn spectra associated to features
 
@@ -134,9 +210,9 @@ spectra, with each spectrum linked to a feature via a propagated
 `feature_id` from the originally matched MS2 spectrum.
 
 ```{r}
-ftms_all_levels <- function(ftms) {
+ftms_all_levels <- function(ftms, ms2) {
 
-  ms2 <- featureSpectra(ftms, msLevel = 2)
+  #ms2 <- featureSpectra(ftms, msLevel = 2)
   cat("Number of MS2 spectra found:", length(ms2), "\n")
 
   res <- lapply(unique(ms2$dataOrigin), function(origin) {
@@ -161,7 +237,7 @@ ftms_all_levels <- function(ftms) {
     do.call(c, res)
 }
 
-ftms_msn_tree <- ftms_all_levels(ftms)
+ftms_msn_tree <- ftms_all_levels(ftms,ms2)
 
 table(msLevel(ftms_msn_tree))
 ```
@@ -186,7 +262,7 @@ spectraData(al[[1]], columns = c("msLevel", "acquisitionNum", "precScanNum"))
 spectraData(al[[2]], columns = c("msLevel", "acquisitionNum", "precScanNum"))
 #' This too.
 
-ft <- "FT0649"
+ft <- "FT0556"
 a <- ftms_msn_tree[ftms_msn_tree$feature_id == ft]
 a
 
@@ -196,18 +272,7 @@ al <- split(a, a$dataOrigin)
 spectraData(al[[1]], columns = c("dataOrigin", "msLevel", "acquisitionNum", "precScanNum", "precursorMz")) |>
     as.data.frame()
 
-#' Looks correct. To feature FT0649, in sample S1R1, there are 4 MS2 spectra linked, which correctly have all the same precursorMz = 285. The four MS2 spectra have acquisitionNum 3851, 3870, 3905, and 3919.
-#' Let's see what filterPrecursorScan does
 
-filterPrecursorScan(al[[1]], 3851)
-filterPrecursorScan(al[[1]], 3870)
-filterPrecursorScan(al[[1]], 3905)
-filterPrecursorScan(al[[1]], 3919)
-
-spectraData(filterPrecursorScan(al[[1]], 3851), columns = c("msLevel", "acquisitionNum", "precScanNum", "precursorMz"))|>as.data.frame()
-spectraData(filterPrecursorScan(al[[1]], 3852), columns = c("msLevel", "acquisitionNum", "precScanNum", "precursorMz"))|>as.data.frame()
-spectraData(filterPrecursorScan(al[[1]], 3854), columns = c("msLevel", "acquisitionNum", "precScanNum", "precursorMz"))|>as.data.frame()
-#' Seems to be OK
 ```
 
 The above result shows that `filterPrecursorScan()` extracts the full
@@ -236,13 +301,7 @@ spdat[spdat$scanIndex %in% 1815:1817,]
 spdat[spdat$feature_id %in% c("FT3146","FT3149"),]
 spdat[spdat$feature_id %in% c("FT0268","FT0270"),]
 ```
-
-In ftms_msn_tree, MS2 that are assigned to multiple features, and all
-dependent spectra (MS3, and MS4), are present multiple times. For
-example: MS2_scandindex381 gives rise to MS3_scandindex382 and
-MS3_scandindex383. Because MS2_scandindex381 was assigned to both
-feature FT0268 and FT0270, these spectra are duplicated in
-ftms_msn_tree: with feature_id = FT0268 and with feature_id = FT0270.
+There is no feature assigned to multiple spectra
 
 # Grouping MSn spectra into fragmentation trees
 
@@ -265,50 +324,75 @@ The output of the `assign_msntree_id()` function is then added to the
 
 ```{r}
 
-assign_msntree_id <- function(x) {
-  ## Order x by MS level: ensures we first assign an ID to the MS2.
+assign_msntree_id_per_feature <- function(x) {
   o <- order(msLevel(x))
   x <- x[o]
-  scan_index <- scanIndex(x)
+
+  scan_index   <- scanIndex(x)
   prec_scan_num <- precScanNum(x)
-  ms_level <- msLevel(x)
-  data_origin <- dataOrigin(x)
+  ms_level     <- msLevel(x)
+  data_origin  <- dataOrigin(x)
+  feature_id   <- x$feature_id
 
   tree_id <- rep(NA_integer_, length(scan_index))
-  global_counter <- 0
 
-  for (origin in unique(data_origin)) {
-    idx <- which(data_origin == origin)
-    origin_scan_index <- scan_index[idx]
-    origin_prec_scan_num <- prec_scan_num[idx]
-    origin_ms_level <- ms_level[idx]
-    origin_tree_id <- rep(NA_integer_, length(idx))
+  # Iterate over features
+  for (feat in unique(feature_id)) {
+    feat_idx <- which(feature_id == feat)
+    feat_scan_index   <- scan_index[feat_idx]
+    feat_prec_scan_num <- prec_scan_num[feat_idx]
+    feat_ms_level     <- ms_level[feat_idx]
+    feat_origin       <- data_origin[feat_idx]
 
-    scan_idx_map <- setNames(seq_along(origin_scan_index), origin_scan_index)
+    # Counter per feature
+    feat_counter <- 0
+    feat_tree_id <- rep(NA_integer_, length(feat_idx))
 
-    for (i in seq_along(idx)) {
-      level <- origin_ms_level[i]
-      if (level == 2) {
-        ## If MS2 hasn't been assigned yet
-        if (is.na(origin_tree_id[i])) {
-          global_counter <- global_counter + 1
-          origin_tree_id[i] <- global_counter
+    # Loop per dataOrigin (optional if you have multiple files)
+    for (origin in unique(feat_origin)) {
+      idx <- which(feat_origin == origin)
+
+      origin_scan_index   <- feat_scan_index[idx]
+      origin_prec_scan_num <- feat_prec_scan_num[idx]
+      origin_ms_level     <- feat_ms_level[idx]
+
+      origin_tree_id <- rep(NA_integer_, length(idx))
+      scan_idx_map <- setNames(seq_along(origin_scan_index), origin_scan_index)
+      ms2_tree_map <- list()
+
+      for (i in seq_along(idx)) {
+        level <- origin_ms_level[i]
+
+        if (level == 2) {
+          this_scan <- origin_scan_index[i]
+          if (!is.null(ms2_tree_map[[as.character(this_scan)]])) {
+            origin_tree_id[i] <- ms2_tree_map[[as.character(this_scan)]]
+          } else {
+            feat_counter <- feat_counter + 1
+            origin_tree_id[i] <- feat_counter
+            ms2_tree_map[[as.character(this_scan)]] <- feat_counter
+          }
+        } else {
+          parent_scan <- origin_prec_scan_num[i]
+          parent_pos  <- scan_idx_map[as.character(parent_scan)]
+          if (length(parent_pos) == 1 && origin_ms_level[parent_pos] == (level - 1)) {
+            origin_tree_id[i] <- origin_tree_id[parent_pos]
+          } else {
+            stop("MS", level, " with ", length(parent_pos), " precursors")
+          }
         }
-      } else {
-        ## Assign ID of the related precursor ID
-        parent_scan <- origin_prec_scan_num[i]
-        parent_pos <- scan_idx_map[as.character(parent_scan)]
-        if (length(parent_pos) == 1 && origin_ms_level[parent_pos] == (level - 1))
-          origin_tree_id[i] <- origin_tree_id[parent_pos]
-        else
-          stop("MS", level, " with ", length(parent_pos), " precursors")
       }
+
+      feat_tree_id[idx] <- origin_tree_id
     }
-    tree_id[idx] <- origin_tree_id
+
+    # Make the IDs globally unique by prefixing with feature_id
+    tree_id[feat_idx] <- paste0(feat, "_", feat_tree_id)
   }
-  ## Return in original order
+
   return(tree_id[order(o)])
 }
+
 
 msntree_ids <- assign_msntree_id(ftms_msn_tree)
 
@@ -317,7 +401,7 @@ spectraVariables(ftms_msn_tree)
 
 ```
 
-The total number of MSn trees:
+The total number of MSn trees is 2157:
 
 ```{r}
 length(unique(ftms_msn_tree$MSntreeID))
@@ -332,7 +416,7 @@ ftms_msn_tree$MSntreeID |>
     quantile()
 ```
 
-There is apparently (at least) one tree with 7 spectra. Extracting this
+There is apparently (at least) one tree with 4 spectra. Extracting this
 particular MSn tree.
 
 We will check MSntreeID of spectra that were assigned to multiple
@@ -356,212 +440,13 @@ max_tree$MSntreeID
 ```
 
 The MSntree with maximum number of spectra corresponds to the tree,
-within dataOrigin S1R3, depending on MS2 with ScanIndex 1814 which was
-assigned to two FeatureIDs: FT3146 and FT3149 Within dataOrigin S1R3,
-scanIndex 1815 (MS3), 1816 (MS3), and 1817 (MS4) are assigned to two
-different features: FT3146, and FT3149.
-
-```{r}
-al <- split(ftms_msn_tree, ftms_msn_tree$dataOrigin)
-S1R3 <- al[[3]]
-double_tree <- S1R3[S1R3$feature_id %in% c("FT3146","FT3149")]
-
-double_tree$rtime
-double_tree$msLevel
-double_tree$precScanNum
-double_tree$scanIndex
-double_tree$feature_id
-double_tree$MSntreeID
-```
-
-Now we check the MSntree corresponding to dataOrigin S1R3 - ScanIndex
-381, which was assigned to two FeatureIDs: FT0268 and FT0270
-
-```{r}
-al <- split(ftms_msn_tree, ftms_msn_tree$dataOrigin)
-S1R3 <- al[[3]]
-double_tree <- S1R3[S1R3$feature_id %in% c("FT0268","FT0270")]
-
-double_tree$rtime
-double_tree$msLevel
-double_tree$precScanNum
-double_tree$scanIndex
-double_tree$feature_id
-double_tree$MSntreeID
-```
-
-Observation of the duplicated spectral trees that were assigned to two
-features (the tree assigned to FT0268 and FT0270, and the trees assigned
-to FT3146 and FT3149) shows a mistake in the assembly of the MSntree
-groups, resulting from forcing MS2 spectra to start a new tree:
-
-Below, spectra are named by their scanIndex: 
-MSntreeID 334 comprises:
-381 (MS2 - FT0268), 382 (MS3 - FT0268), 383 (MS3 - FT0268) , **382 (MS3 -
-FT0270)**, **383 (MS3 - FT0270)**
-
-MSntreeID 336 comprises:
-**381 (MS2 - FT0270)**
-
-MSntreeID 335 comprises:
-324 (MS2 - FT0270), 326 (MS3 - FT0270)
-
-MSntreeID 433 comprises:
-1814 (MS2 - FT3146), 1815 (MS3 - FT3146), 1816 (MS3 - FT3146) , 1817 (MS4 - FT3146), **1815 (MS3 -
-FT3149)**, **1816 (MS3 - FT3149)**, **1817 (MS4 - FT3149)
-
-MSntree 444 comprises:
-**1814 (MS2 - FT3149)**
-
-**In both cases, the duplicated spectral tree that was assigned to another chromatographic feature, has been split: the MS2 spectrum was assigned to a new MSntree, whereas the higher level spectra were associated as doubles to the MSntree associated with the first chromatographic feature.**
-
-Below, we have a closer look at these two features.
-
-```{r}
-feat <- c("FT3146","FT3149")
-feat_idx <- ms2sp$feature_id %in% feat
-ms2sp[feat_idx,]
-```
-
-Features FT3146, and FT3149 have almost exactly the same mzmin and
-mzmax, but 10 seconds difference in rtmed. We have a look at EICs for
-these features.
-
-```{r}
-fdefs <- featureDefinitions(ftms)
-feature_ids <- rownames(fdefs) 
-#FT3146
-fid <- "FT3146"
-finfo <- fdefs[fid, ]
-eic1 <- chromatogram(
-  ftms,
-  mz = c(finfo$mzmin, finfo$mzmax),
-  rt = c(1000, 1100)
-)
-
-#FT3149
-fid <- "FT3149"
-finfo <- fdefs[fid, ]
-eic2 <- chromatogram(
-  ftms,
-  mz = c(finfo$mzmin, finfo$mzmax),
-  rt = c(1000, 1100)
-)
-
-par(mfrow = c(2, 1))
-plot(eic1)
-plot(eic2)
-
-```
+within dataOrigin S1R5, depending on MS2 with ScanIndex 103 which was
+assigned to one FeatureID: FT1717 Within dataOrigin S1R5,
+scanIndex 104 (MS3), 105 (MS3), and 106 (MS4) are assigned to a single
+feature: FT1717.
 
 
-```{r}
-fdefs <- featureDefinitions(ftms)
-feature_ids <- rownames(fdefs) 
-#FT0268
-fid <- "FT0268"
-finfo <- fdefs[fid, ]
-eic1 <- chromatogram(
-  ftms,
-  mz = c(finfo$mzmin, finfo$mzmax),
-  rt = c(150, 250)
-)
 
-#FT0270
-fid <- "FT0270"
-finfo <- fdefs[fid, ]
-eic2 <- chromatogram(
-  ftms,
-  mz = c(finfo$mzmin, finfo$mzmax),
-  rt = c(150, 250)
-)
-
-par(mfrow = c(2, 1))
-plot(eic1)
-plot(eic2)
-
-```
-
-# What to do with spectra assigned to multiple features?
-The chromatographic peaks of these two features are quite similar. Maybe we could merge the two features in case spectra are assigned to both. 
-We could also change the method of `featureSpectra()` to assign MS2 spectra to the single chromatographic feature that is closest in retention time (and within an m/z range) ==> each MSntree will be assigned to a single feature.
-In reality, these are probably two different isomers and the spectra are most probably derived from a mixture. 
-If we want to keep duplicated spectral trees assigned to different features, we need to modify the function `assign_msntree_id()`.
-When selecting an MSntree to add to the database, it is important to take the purity of the precursor into account. If an MS2 falls within mz and rt range of two features, it maybe not pure and priority could be given to spectra that can only be assigned to a single feature.
-
-# Merging two features in an XcmsExperiment object
-The code below merges two specific features in an XcmsExperiment object.
-Applying `ftms_all_levels()` and `assign_msntree_id`to the new XcmsExperiment object did not solve the problem, and the code needs to be optimized IF we decide that we want to go this way (merging peaks).
-
-```{r}
-# Manually merging two features in an XcmsExperiment object
-# Extract feature definitions, chromPeaks, and Sample Data
-fdefs <- featureDefinitions(ftms)
-cp <- chromPeaks(ftms)
-sdata <- sampleData(ftms)
-
-# Extract the two feature IDs to merge
-fid1 <- "FT3146"
-fid2 <- "FT3149"
-
-f1 <- fdefs[fid1, ]
-f2 <- fdefs[fid2, ]
-
-# Merge the peak indices
-merged_peakidx <- unique(c(unlist(f1$peakidx), unlist(f2$peakidx)))
-
-# Get sample indices for merged peaks
-sample_indices <- cp[merged_peakidx, "sample"]
-
-# Determine sample group membership
-sample_group_membership <- sdata$sample_id[sample_indices]
-sample_counts <- table(factor(sample_group_membership, levels = unique(sample_groups)))
-
-# Construct merged feature row
-merged_feature <- DataFrame(
-  mzmed = mean(c(f1$mzmed, f2$mzmed)),
-  mzmin = min(f1$mzmin, f2$mzmin),
-  mzmax = max(f1$mzmax, f2$mzmax),
-  rtmed = mean(c(f1$rtmed, f2$rtmed)),
-  rtmin = min(f1$rtmin, f2$rtmin),
-  rtmax = max(f1$rtmax, f2$rtmax),
-  npeaks = as.numeric(length(unique(sample_names))),
-  peakidx = I(list(merged_peakidx)),
-  ms_level = unique(c(f1$ms_level, f2$ms_level))
-)
-
-# Add per-group sample columns
-group_cols <- colnames(fdefs)[colnames(fdefs) %in% names(sample_counts)]
-for (grp in group_cols) {
-  merged_feature[[grp]] <- as.numeric(sample_counts[[grp]])
-}
-merged_feature <- merged_feature[, colnames(fdefs)]
-
-# Replace original features with merged one
-fdefs_new <- fdefs[!(rownames(fdefs) %in% c(fid1, fid2)), ]
-fdefs_new <- rbind(fdefs_new, as.data.frame(merged_feature))
-rownames(fdefs_new)[nrow(fdefs_new)] <- paste0(fid1, "_", fid2, "_merged")
-
-# Update the XcmsExperiment object
-featureDefinitions(ftms) <- fdefs_new
-
-
-```
-
-TODO: After merging two features: in spectraData of ftms_msn_tree
-(sampleOrigin S1R3), scanIndex 1815, 1816, 1817 are double. One should
-be removed.
-
-```{r}
-al <- split(ftms_msn_tree, ftms_msn_tree$dataOrigin)
-S1R3 <- al[[3]]
-spdat  <-spectraData(S1R3)
-spdat[spdat$scanIndex %in% 1815:1817,]
-
-```
-
-TODO: create code to check if MSn_trees are assigned to more than one
-feature
 
 ```{r}
 ## we stored the tree ids and the msLevels to a dataframe
@@ -579,9 +464,9 @@ table(max_level_per_tree$max_level)
 
 ```
 
-The number of trees that go up to MS2 level is : 415 The number of trees
-that go up to MS3 level is : 338 The number of trees that go up to MS4
-level is : 926
+The number of trees that go up to MS2 level is : 727 The number of trees
+that go up to MS3 level is : 297 The number of trees that go up to MS4
+level is : 1133
 
 Next we select one most representative tree per feature based on the
 longest one and if we have many, we select one tree with the highest MS2
@@ -630,7 +515,7 @@ msLevel(ftms_one_tree) |> table()
 ```
 
 after selecting one representative tree per feature we have now: MS2 :
-437, MS3 : 523, MS4 : 262
+519, MS3 : 573, MS4 : 285
 
 Finally we verify if the number of unique features corresponds to the
 number of unique MSntreeID to ensure that we have one tree per feature.
@@ -643,13 +528,13 @@ length(unique(ftms_one_tree$feature_id))
 length(unique(ftms_one_tree$MSntreeID))
 ```
 
-we have 437 unique feature and unique MSntreeID, That's mean that we
+we have 519 unique feature and unique MSntreeID, That's mean that we
 have for each feature one representative tree.
 
 Now we save the resulting ftms spectra object to a local directory.
 
 ```{r}
-save(ftms_one_tree, file = file.path(pth, "data", "ftms_one_tree.RData"))
+save(ftms_one_tree, file = file.path(pth, "data", "ftms_one_tree_sh.RData"))
 ```
 
 # Session information

--- a/ftms_preprocessing.qmd
+++ b/ftms_preprocessing.qmd
@@ -3,14 +3,17 @@ title: "Semi-automated library generation; FTMS LC-MSn data"
 format: html
 editor_options:
   chunk_output_type: inline
+editor: 
+  markdown: 
+    wrap: 72
 ---
 
 # Introduction
 
 In this document, we present all the main steps for analyzing FTMS data,
-including data visualization, preprocessing, *xcms* preprocessing including
-retention time alignment. We also plotted the extracted ion chromatograms of
-some known compounds.
+including data visualization, preprocessing, *xcms* preprocessing
+including retention time alignment. We also plotted the extracted ion
+chromatograms of some known compounds.
 
 # Data import
 
@@ -21,7 +24,6 @@ We first load all required R packages for the analysis in this document.
 library(MsExperiment)
 library(Spectra)
 library(xcms)
-library(MsExperiment)
 library(readxl)
 library(pander)
 library(pheatmap)
@@ -31,22 +33,23 @@ register(SerialParam())
 Next we read the LC-MSn data from the mzML data files.
 
 The sample/file information is retrieved from an Excel file
-*ftms_data_files.xlsx* that must meet the following minimal requirements:
+*ftms_data_files.xlsx* that must meet the following minimal
+requirements:
 
-– A column named *data_file* containing the filenames of the *.mzML* files.
-– A column named *sample_name* with the corresponding sample names. The sample
-  name for blank control files should be `"blank"`.
-– A column named *sample_id*.
+– A column named *data_file* containing the filenames of the *.mzML*
+files. – A column named *sample_name* with the corresponding sample
+names. The sample name for blank control files should be `"blank"`. – A
+column named *sample_id*.
 
-All files should be placed locally within the working directory containing also
-this file (i.e., *ftms-preprocessing.qmd*). The directory hierarchy is expected
-to be the following:
+All files should be placed locally within the working directory
+containing also this file (i.e., *ftms-preprocessing.qmd*). The
+directory hierarchy is expected to be the following:
 
-– *<my.workdir>/data/mzML*: directory containing all *.mzML* files.
-– *<my.workdir>/data/sample_data/*: directory containing the Excel file with the
-  sample and file information.
+– *\<my.workdir\>/data/mzML*: directory containing all *.mzML* files. –
+*\<my.workdir\>/data/sample_data/*: directory containing the Excel file
+with the sample and file information.
 
-In the following code, *<my.workdir>* is the working directory:
+In the following code, *\<my.workdir\>* is the working directory:
 
 ```{r}
 pth <- getwd()
@@ -59,8 +62,8 @@ now we import our dataset
 sample_data_ftms <- read_xlsx(
     file.path(pth, "data/sample_data/ftms_data_files.xlsx")) |>
     as.data.frame()
-fp <- file.path(pth, "data", "mzML")
-ftms <- readMsExperiment(file.path(fp, sample_data_ftms$data_file),
+MZML_PATH <- file.path(pth,"data","mzML")
+ftms <- readMsExperiment(file.path(MZML_PATH, sample_data_ftms$data_file),
                          sampleData = sample_data_ftms)
 ftms
 ```
@@ -89,7 +92,6 @@ col_sample_ftms <- col_sample_ftms_id[sampleData(ftms)$sample_id]
 
 Then we plot the **base peak chromatogram** for all samples :
 
-
 ```{r}
 #| fig-width: 10
 #| fig-height: 5
@@ -100,8 +102,8 @@ grid()
 
 This BPC shows that there is no signal detected after 3500 seconds.
 
-We next clean the data set filtering to a retention time range of 10-3500
-seconds.
+We next clean the data set filtering to a retention time range of
+10-3500 seconds.
 
 ```{r}
 ftms <- filterSpectra(ftms, filterRt, c(10, 3500))
@@ -110,8 +112,8 @@ msLevel(spectra(ftms)) |>
 
 ```
 
-This data contains 4 MS levels but with empty spectra so we removed them using
-`filterEmptySpectra()` function.
+This data contains 4 MS levels but with empty spectra so we removed them
+using `filterEmptySpectra()` function.
 
 ```{r}
 ftms <- filterSpectra(ftms, filterEmptySpectra)
@@ -127,9 +129,9 @@ plot(bpc0, col = paste0(col_sample_ftms, 80))
 grid()
 ```
 
-We next extract a total ion chromatogram (TIC) and base peak chromatogram (BPC)
-and calculate the similarities between these to evaluate similarity in the
-performance of the liquid chromatography.
+We next extract a total ion chromatogram (TIC) and base peak
+chromatogram (BPC) and calculate the similarities between these to
+evaluate similarity in the performance of the liquid chromatography.
 
 ```{r}
 #' Extract TIC
@@ -156,7 +158,8 @@ pheatmap(ticmap, cluster_cols = FALSE,
          annotation_row = ann)
 ```
 
-There is no clear separation of the signal by the seed information (S1, S9).
+There is no clear separation of the signal by the seed information (S1,
+S9).
 
 Now we plot the tic
 
@@ -203,8 +206,11 @@ grid()
 
 # Data preprocessing
 
-To derive the settings for the chromatographic peak detection for the present
-data set we below extract the ion signal for an m/z range of an known compound.
+## Determination of peak width parameters for chromatographic peak detection
+
+To derive the settings for the chromatographic peak detection for the
+present data set we below extract the ion signal for an m/z range of a
+known compound.
 
 ```{r}
 mzr <- c(287.04, 287.06)
@@ -215,7 +221,8 @@ grid()
 
 ```
 
-We zoom into a small retention time range that contains the highest peak signal.
+We zoom into a small retention time range that contains the highest peak
+signal.
 
 ```{r}
 #' Focus on the retention time range with the highest signal
@@ -234,11 +241,13 @@ tmp <- filterMz(ftms, mz = mzr) |>
 plot(tmp[1])
 ```
 
-Here we do the same thing as qtof to choose the peakwidth parameter, but here we
-used the ion chromatogram of a known compound, its width is about 40 seconds so
-we take the half and the double that’s mean 20 and 80 as a parameter window.
+Here we do the same thing as qtof to choose the peakwidth parameter, but
+here we used the ion chromatogram of a known compound, its width is
+about 40 seconds so we take the half and the double - that’s 20 and 80 -
+as a parameter window.
 
-Next we run the chromatographic peak detection on that extracted ion chromatogram.
+Next we run the chromatographic peak detection on that extracted ion
+chromatogram.
 
 ```{r}
 a_kn2 <- findChromPeaks(a_kn, CentWaveParam(peakwidth = c(20, 80),
@@ -260,7 +269,7 @@ par(mfrow = c(1, 2))
 #' In one sample
 plot(a_kn2[, 1], xlim = c(1390, 1450))
 grid()
-#' In all samples
+#' In five samples
 plot(a_kn2[, 1:5], xlim = c(1390, 1450))
 grid()
 ```
@@ -291,37 +300,14 @@ grid()
 
 Eventually we could try another m/z range...
 
-```{r}
-plot(bpc)
-grid()
-abline(v = c(1020, 1100), col = "grey")
-plot(bpc[, 1], xlim = c(1020, 1100))
-```
+## Peak detection on full dataset
 
-Below we extract the ion chromatogram for this m/z range.
-
-```{r}
-mzr <- c(287.04, 287.06)
-
-a <- chromatogram(ftms, mz = mzr, aggregationFun = "max")
-plot(a, col = paste0(col_sample_ftms, 80))
-grid()
-```
-
-This m/z range seems to contain signal from several ions, eluting at different
-retention times. We next focus on a retention time range to inspect the signal
-from a single ion.
-
-```{r}
-plot(a, col = paste0(col_sample_ftms, 80), xlim = c(1400, 1500))
-grid()
-```
-
-We next perform the chromatographic peak detection using the centWave
-algorithm. With integrate = 2 we use an alternative algorithm to correctly
-identify the boundaries of the identified chromatographic peaks. Parameter
-chunkSize is used to control the number of files from which the data should be
-loaded into memory at a time.
+We next perform the chromatographic peak detection, using the centWave
+algorithm, on the full `MsExperiment`object, containing data of ten MzML
+files. With integrate = 2 we use an alternative algorithm to correctly
+identify the boundaries of the identified chromatographic peaks.
+Parameter chunkSize is used to control the number of files from which
+the data should be loaded into memory at a time.
 
 ```{r}
 ftms <- findChromPeaks(
@@ -329,25 +315,35 @@ ftms <- findChromPeaks(
     chunkSize = 2)
 ```
 
-With this setting we identified `r nrow(chromPeaks(ftms))` peaks in the full
-data set. The number of peaks per sample are:
+> The `xcms::findChromPeaks()` function transforms the
+> `MsExperiment` object (originally created using
+> `MsExperiment::readMsExperiment()` with mzML files and sample
+> metadata) into an `XcmsExperiment` object.
+>
+> `XcmsExperiment` is an extension of `MsExperiment`, allowing to
+> include chromatographic peak information, alignment and grouping, all
+> generated by core `xcms` functions.
+
+With this setting we identified `r nrow(chromPeaks(ftms))` peaks in the
+full data set. The number of peaks per sample are:
 
 ```{r}
 pks <- chromPeaks(ftms)
 table(pks[, "sample"])
 ```
 
-The distribution of the peak widths in retention time and in m/z dimensions are:
+The distribution of the peak widths in retention time and in m/z
+dimensions are:
 
 ```{r}
 quantile(unname(pks[, "rtmax"] - pks[, "rtmin"]))
 quantile(unname(pks[, "mzmax"] - pks[, "mzmin"]))
 ```
 
-We next perform the chromatographic peak refinement to reduce the number of
-potential centWave-specific peak detection artifacts. We choose settings that
-depend on the observed peak widths above (i.e. half of the observed average
-widths).
+We next perform the **chromatographic peak refinement** to reduce the
+number of potential centWave-specific peak detection artifacts. We
+choose settings that depend on the observed peak widths above (i.e. half
+of the observed median widths).
 
 ```{r}
 mnpp <- MergeNeighboringPeaksParam(expandRt = 9.67525, expandMz = 0.0006)
@@ -364,9 +360,11 @@ quantile(unname(pks[,"rtmax"] - pks[,"rtmin"]))
 quantile(unname(pks[,"mzmax"] - pks[,"mzmin"]))
 ```
 
-We next perform an initial correspondence analysis that is needed for the
-subsequent retention time alignment. We evaluate the settings on the example m/z
-range from above.
+## Retention time alignment
+
+We next perform an initial correspondence analysis that is needed for
+the subsequent retention time alignment. We evaluate the settings on the
+example m/z range from above.
 
 ```{r}
 #| fig-width: 10
@@ -401,7 +399,8 @@ plotChromPeakDensity(
 grid()
 ```
 
-Correspondence with the selected settings seems to correctly group features.
+Correspondence with the selected settings seems to correctly group
+features.
 
 ```{r}
 ftms <- groupChromPeaks(ftms, param = pdp)
@@ -421,16 +420,16 @@ ftms <- adjustRtime(ftms, param = pgp)
 ```
 
 Below we plot the results from the retention time alignment, i.e., the
-difference between the original and adjusted retention times (y-axis) along the
-retention time axis (x-axis).
+difference between the original and adjusted retention times (y-axis)
+along the retention time axis (x-axis).
 
 ```{r}
 plotAdjustedRtime(ftms, col = paste0(col_sample_ftms, 80))
 grid()
 ```
 
-We can see from the plot above that there is one sample that has been largely
-adjusted, so it goes up to 15 seconds.
+We can see from the plot above that there is one sample that has been
+largely adjusted, so it goes up to 15 seconds.
 
 ```{r}
 bpc_adj <- chromatogram(ftms, aggregationFun = "max")
@@ -458,15 +457,16 @@ pheatmap(bpcmap, cluster_cols = FALSE,
 
 we see that S1 and S9 are well grouped after retention time alignment.
 
-Now we can visualize the changes before and after retention time alignment
+Now we can visualize the changes before and after retention time
+alignment
 
 ```{r}
 bpc_adj <- chromatogram(ftms, aggregationFun = "max", chromPeaks = "none")
 a_adj <- chromatogram(ftms, aggregationFun = "max", mz = mzr)
 ```
 
-We first plot the BPC of the original data and then of the data after retention
-time alignment.
+We first plot the BPC of the original data and then of the data after
+retention time alignment.
 
 ```{r}
 #| fig-width: 10
@@ -495,8 +495,8 @@ plot(bpc_adj, col = paste0(col_sample_ftms, 80))
 grid()
 ```
 
-The data looks well aligned, next we need to visualize the alignment result on a
-smaller retention time range.
+The data looks well aligned, next we need to visualize the alignment
+result on a smaller retention time range.
 
 ```{r}
 par(mfrow = c(1, 1))
@@ -510,8 +510,8 @@ plot(bpc_adj, col = paste0(col_sample_ftms, 80), xlim = c(400, 500))
 grid()
 ```
 
-The data looks well aligned, From this results we can conclude that retention
-time alignment works well on this data.
+The data looks well aligned, From this results we can conclude that
+retention time alignment works well on this data.
 
 We in addition evaluate the signal for the example m/z range.
 
@@ -523,8 +523,8 @@ plot(a_adj, col = paste0(col_sample_ftms, 80))
 grid()
 ```
 
-the data seems to be better aligned. Finally, we zoom into a retention time
-window from 1300 to 1500 seconds.
+the data seems to be better aligned. Finally, we zoom into a retention
+time window from 1300 to 1500 seconds.
 
 ```{r}
 par(mfrow = c(2, 1))
@@ -534,11 +534,12 @@ plot(a_adj, col = paste0(col_sample_ftms, 80),
      xlim = c(1300, 1500), peakType = "none")
 ```
 
-We can thus conclude that the settings for the retention time alignment worked
-on the present data set. We continue the preprocessing with the final
-correspondence analysis. We adapt now the settings, in particular the bw
-parameter, that can be much stricter because of the properly aligned data
-set. Again, we test the settings on the extracted ion signal.
+We can thus conclude that the settings for the retention time alignment
+worked on the present data set. We continue the preprocessing with the
+final correspondence analysis. We adapt now the settings, in particular
+the bw parameter, that can be much stricter because of the properly
+aligned data set. Again, we test the settings on the extracted ion
+signal.
 
 ```{r}
 #' Configure settings
@@ -562,14 +563,14 @@ plotChromPeakDensity(a_adj_2, param = pdp, col = col_sample_ftms)
 
 ```
 
-now we group chromatographic peak
+now we group chromatographic peaks
 
 ```{r}
 ftms <- groupChromPeaks(ftms, param = pdp)
 ```
 
-As a final step we next perform gap-filling to reduce the number of missing
-values in the data set.
+As a final step we next perform gap-filling to reduce the number of
+missing values in the data set.
 
 ```{r}
 #' The number of missing values before gap filling
@@ -601,7 +602,6 @@ msLevel(spectra(ftms)) |>
   table()
 ```
 
-
 We next save the raw and adjusted BPC to a image file.
 
 ```{r}
@@ -621,6 +621,9 @@ grid()
 
 dev.off()
 ```
+
+## Feature matrix
+
 Now we will create the feature matrix of this data.
 
 ```{r}


### PR DESCRIPTION
After applying featureSpectra() I kept only one MS2 spectrum if it was linked to two different features, selecting the one closest in retention time. Then I assigned an MSntreeID to each feature tree, and finally I retained just one tree per feature (the longest one, and in case of ties, the one with the highest MS2 precursor intensity).

PS: I used the data after setting snthresh = 2 in CentwaveParam() and minFraction = 0.5 in PeakDensityParam() ([link](https://github.com/rebdau/RDynLib_ftms/issues/12#issuecomment-3209623990)
).