### PR TITLE
Change parameters for peak detection, refinement and correspondence

### DIFF
--- a/ftms_preprocessing.qmd
+++ b/ftms_preprocessing.qmd
@@ -3,8 +3,8 @@ title: "Semi-automated library generation; FTMS LC-MSn data"
 format: html
 editor_options:
   chunk_output_type: inline
-editor: 
-  markdown: 
+editor:
+  markdown:
     wrap: 72
 ---
 
@@ -303,15 +303,16 @@ Eventually we could try another m/z range...
 ## Peak detection on full dataset
 
 We next perform the chromatographic peak detection, using the centWave
-algorithm, on the full `MsExperiment`object, containing data of ten MzML
-files. With integrate = 2 we use an alternative algorithm to correctly
+algorithm, on the full `MsExperiment`object, containing data of ten mzML
+files. With `integrate = 2` we use an alternative algorithm to correctly
 identify the boundaries of the identified chromatographic peaks.
-Parameter chunkSize is used to control the number of files from which
+Parameter `chunkSize` is used to control the number of files from which
 the data should be loaded into memory at a time.
 
 ```{r}
 ftms <- findChromPeaks(
-    ftms, CentWaveParam(peakwidth = c(20, 80), integrate = 2, snthresh = 2),
+    ftms, CentWaveParam(peakwidth = c(20, 80), integrate = 2, snthresh = 2,
+                        ppm = 50, prefilter = c(3, 500), mzdiff = 0.001),
     chunkSize = 2)
 ```
 
@@ -342,11 +343,12 @@ quantile(unname(pks[, "mzmax"] - pks[, "mzmin"]))
 
 We next perform the **chromatographic peak refinement** to reduce the
 number of potential centWave-specific peak detection artifacts. We
-choose settings that depend on the observed peak widths above (i.e. half
+choose settings that depend on the observed peak widths above (i.e., about half
 of the observed median widths).
 
 ```{r}
-mnpp <- MergeNeighboringPeaksParam(expandRt = 9.67525, expandMz = 0.0006)
+mnpp <- MergeNeighboringPeaksParam(expandRt = 10, expandMz = 0.001,
+                                   minProp = 0.66)
 ftms <- refineChromPeaks(ftms, mnpp)
 ```
 
@@ -355,6 +357,7 @@ refinement.
 
 ```{r}
 pks <- chromPeaks(ftms)
+nrow(pks)
 table(pks[, "sample"])
 quantile(unname(pks[,"rtmax"] - pks[,"rtmin"]))
 quantile(unname(pks[,"mzmax"] - pks[,"mzmin"]))
@@ -374,10 +377,9 @@ example m/z range from above.
 a_2 <- chromatogram(ftms, aggregationFun = "max", mz = mzr)
 
 #' Configure settings
-
 pdp <- PeakDensityParam(sampleGroups = sampleData(ftms)$sample_id,
-                        bw = 6, minFraction = 0.3)
-
+                        bw = 6, minFraction = 0.3, binSize = 0.1,
+                        ppm = 10)
 #' Evaluate settings on the full range
 plotChromPeakDensity(
     a_2, param = pdp, col = paste0(col_sample_ftms, 80),
@@ -544,7 +546,8 @@ signal.
 ```{r}
 #' Configure settings
 pdp <- PeakDensityParam(sampleGroups = sampleData(ftms)$sample_id,
-                        bw = 2, minFraction = 0.3)
+                        bw = 2, minFraction = 0.3, binSize = 0.1,
+                        ppm = 10)
 
 #' Evaluate settings on the full range
 plotChromPeakDensity(a_adj, param = pdp, col = col_sample_ftms)


### PR DESCRIPTION
This PR changes some of the parameters for peak detection, refinement and correspondence, based on @rebdau 's observations (in this [comment](https://github.com/rebdau/RDynLib_ftms/pull/15#discussion_r2318315745)).

To summarize:

1) peak detection (`CentWaveParam`) I changed:
-  `ppm = 50`: this *ppm* defines the maximal allowed deviation of the m/z for mass peaks to be included in the same chromatographic peak. It does not have a huge impact, but in our experience it was always better to keep it a bit higher to avoid that chromatographic peaks get split into separate peaks.
- `prefilter = c(3, 500)`: this simply ensures that each chromatographic peak has at least 3 mass peaks with an intensity > 500 - to avoid picking up noise as peaks mostly.
- `mzdiff = 0.001`: using this small positive value (instead of the default) causes that for overlapping chromatographic peaks (overlapping in m/z and rt) only the larger one is kept and refined. The influence of this parameter should not be too large because we're *refining* peaks anyway in the next step. But it helps to avoid very long "tails" on the chromatographic peaks.

2) peak refinement (`RefineChromPeaksParam`):
- `expandRt = 10`: I just rounded the value we had to the next integer
- `expandRt = 0.001`: here I increased the value a bit - but should not have a large impact.
- `minProp = 0.66`: this I changed from the default `0.75` to `0.66`, so, chromatographic peaks get merged if the signal between them is higher than 2/3 of the higher chromatographic peaks intensity. This was to fix the noisy, but separated peaks we have seen.

3) correspondence analysis (`PeakDensityParam`):
- `binSize = 0.1` (changed from the default `0.25`). Chromatographic peaks close in retention time and with a m/z below this value are grouped into a feature. We could eventually also reduce it further - the previous `0.25` was definitely too large. But in the end this did not change too much.
- `ppm = 10` (was `ppm = 0`). This `ppm` is added to the `binSize` value above, so accepting larger m/z deviations for larger m/z values.

These where the changes I made, but I checked just quickly what the impact was. Maybe if you @rebdau and @Ahlammentag could also have a look if the data/results improved a bit would be cool :)

And of course, these settings are just some suggestions based on what we've seen - from own experience I find it very hard/impossible to find settings that solve **all** problems - there is always a tradeoff for how much problematic/noisy signal one accepts.