### PR TITLE
Extensive feature/MS2 evaluation for ambiguous MS2

### DIFF
--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -101,7 +101,8 @@ perc_features_with_ms2
 
 ```
 
-The percentage of features with at least one MS2 is 8.46%
+The total number of features with at least one MS2 is `r n_features_with_ms2`,
+which corresponds to `r format(perc_features_with_ms2, digits = 3)`%.
 
 A summary on the number of MS2 spectra assigned to a feature is shown
 below:
@@ -124,15 +125,14 @@ sp$groups <- paste0(sp$dataOrigin, "_", sp$scanIndex)
 # Number of MS2 spectra assigned to features
 n_assigned_ms2 <- length(unique(sp$groups))
 
-
-
 # Percentage assigned
 perc_ms2_assigned <- (n_assigned_ms2 / n_total_ms2) * 100
 perc_ms2_assigned
 
 ```
 
-the percentage of MS2 spectra that are assigned to a feature is 17%
+The total number of assigned MS2 spectra is `r n_assigned_ms2`, which
+corresponds to a percentage of `r format(perc_ms2_assigned, digits = 3)`.
 
 Note that an MS2 spectrum could also be assigned to more than one
 feature. The total number of MS2 spectra assigned to more than one
@@ -260,16 +260,16 @@ increasing the sn ratio again
 for (id in ms2_mult) {
   a <- ms2[ms2_id == id]
   spa <- spectraData(a)
-  
+
   mzmeds <- spa$feature_mzmed
   uniq_mzmeds <- unique(mzmeds)
-  
+
   cat("Checking id:", id, "\n")
   cat("All mzmeds:", paste(round(mzmeds, 5), collapse = ", "), "\n")
   cat("Unique mzmeds:", paste(round(uniq_mzmeds, 5), collapse = ", "), "\n")
-  
+
   print(spa[, c("feature_id", "feature_rtmed", "feature_mzmed")])
-  
+
 }
 
 ```
@@ -282,7 +282,7 @@ ids1 <- c("FT4356", "FT4357")
 a_chr1 <- featureChromatograms(ftms, features = ids1)
 
 plot(a_chr1[1])
-abline(v = 462.84, col = "red", lty = 2)  
+abline(v = 462.84, col = "red", lty = 2)
 
 plot(a_chr1[2])
 abline(v = 470.61, col = "red", lty = 2)
@@ -409,7 +409,7 @@ threshold <- round(threshold,3)
 #reduce dataset to ms2_id_significant
 spar <- spa[spa$ms2_id %in% ms2_id_significant,]
 spar$ms2_id <- factor(spar$ms2_id)
-split_deltas <- split(abs(spar$delta), 
+split_deltas <- split(abs(spar$delta),
                       spar$ms2_id)
 close_counts <- sapply(split_deltas, function(x) sum(x <= threshold, na.rm = TRUE))
 

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -67,7 +67,7 @@ msLevel(ms2) |>
 spectraData(ms2)
 ```
 
-it returns 2115 MS level 2 spectra. The total number of features for
+it returns `r length(ms2)` MS level 2 spectra. The total number of features for
 which an MS2 spectrum was identified is:
 
 ```{r}
@@ -113,7 +113,7 @@ table(ms2$feature_id) |>
 ```
 
 The median number of MS2 spectra per feature (across all data files) is
-hence 3.
+hence `r median(table(ms2$feature_id))`.
 
 the percentage of MS2 spectra that are assigned to a feature
 
@@ -139,18 +139,473 @@ feature. The total number of MS2 spectra assigned to more than one
 feature is:
 
 ```{r}
-ms2_id <- paste0(ms2$dataOrigin, ms2$acquisitionNum)
-ms2_mult <- names(table(ms2_id)[table(ms2_id) > 1])
-length(ms2_mult)
-table(table(ms2_id))
-minimumone <- sum(table(table(ms2_id)))
-ms2_three <- names(table(ms2_id)[table(ms2_id) == 3])
-cat("Of the MS2 spectra that were assigned to at least one feature ",length(ms2_mult)*100/minimumone,"% was assigned to multiple features.\n")
+ms2_id <- paste0(ms2$dataOrigin, "_", ms2$acquisitionNum)
+ms2_table <- table(ms2_id)
+ms2_mult <- names(ms2_table)[ms2_table > 1]
 
 ```
 
-Most MS2 spectra that are assigned to more than one feature, are
-assigned to two features (59 MS2 spectra).
+Of the `r length(unique(ms2_id))` MS2 spectra, `r length(ms2_mult)` are assigned
+to more than one feature. Below we evaluate to how many features these MS2
+spectra are assigned:
+
+```{r}
+quantile(ms2_table[ms2_table > 1])
+```
+
+All MS2 spectra that are assigned to more than one feature, are
+assigned to two features.
+
+We next identify the features to which these MS2 spectra are assigned.
+
+```{r}
+ms2_mult_features <- sp$feature_id[sp$groups %in% ms2_mult]
+```
+
+The `r length(ms2_mult)` ambiguous MS2 features are assigned in to in total
+`r length(unique(ms2_mult_features))` features. These are listed, along with the
+number of assigned ambiguous MS2 spectra in the table below.
+
+```{r, results = "asis"}
+tmp <- table(ms2_mult_features) |> as.data.frame()
+colnames(tmp) <- c("feature_id", "freq")
+tmp <- tmp[order(tmp$freq, decreasing = TRUE), ]
+rownames(tmp) <- NULL
+library(pander)
+pandoc.table(tmp, style = "rmarkdown")
+```
+
+
+## Evaluation of ambiguous MS2 spectra assignment
+
+We next evaluate some of the ambiguous assignment of the same MS2 spectrum to
+multiple features.
+
+### Example 1
+
+```{r}
+fid <- as.character(tmp$feature_id[1L])
+```
+
+Information on the feature is summarized below.
+
+```{r, results = "asis"}
+feature_summary_table <- function(x, id) {
+    fd <- featureDefinitions(x)[id, ]
+    fa <- featureArea(x, features = id)
+    data.frame(
+        mzmed = fd$mzmed,
+        mzwidth = fd$mzmax - fd$mzmin,
+        mzwidth_full = fa[1L, "mzmax"] - fa[1L, "mzmin"],
+        rtmed = fd$rtmed,
+        rtwidth = fd$rtmax - fd$rtmin,
+        rtwidth_full = fa[1L, "rtmax"] - fa[1L, "rtmin"],
+        chrom_peak_count = length(fd$peakidx[[1L]])
+    )
+}
+tab <- feature_summary_table(ftms, fid)
+pandoc.table(tab, style = "rmarkdown", split.table = Inf)
+```
+
+Next we evaluate whether the current feature shared chromatographic peaks with
+any other feature:
+
+```{r}
+#' Function to get the index of chromatographic peaks shared with other
+#' features for a feature with ID `id`.
+#'
+#' @noRd
+shared_chrom_peaks <- function(x, id) {
+    pids <- unlist(featureDefinitions(x)[id, "peakidx"])
+    other_features <- lapply(featureDefinitions(x)$peakidx,
+                             function(z) z[z %in% pids])
+    names(other_features) <- rownames(featureDefinitions(x))
+    other_features <- other_features[lengths(other_features) > 0]
+    other_features[names(other_features) != id]
+}
+
+## are chrom peaks shared with other feature?
+shared_cpks <- shared_chrom_peaks(ftms, fid)
+shared_cpks
+```
+
+No chromatographic peaks are shared. Next we summarize the number of ambiguous
+MS2 spectra and the feature(s) with which they are shared.
+
+```{r, results = "asis"}
+#' Get all MS2 for the current feature
+fid_ms2 <- ms2[ms2$feature_id == fid]
+#' Get the ambiguous MS2 for current feature
+fid_ms2_mult <- intersect(ms2_mult, ms2_id[ms2$feature_id == fid])
+#' Get the other features for the ambiguous MS2 of current feature
+fid_other_features <- setdiff(ms2$feature_id[ms2_id %in% fid_ms2_mult], fid)
+
+tab <- data.frame(ms2_count = length(fid_ms2),
+                  ambiguous_ms2_count = length(fid_ms2_mult),
+                  other_feature = paste0(fid_other_features, collapse = ","))
+pandoc.table(tab, style = "rmarkdown", split.table = Inf)
+```
+
+A considerable number of MS2 spectra are shared with another feature. We next
+visually inspect their data, i.e., their EIC and the retention time where the
+unambiguous and ambiguous MS2 were detected.
+
+```{r}
+fid_eic <- featureChromatograms(ftms, features = fid)
+other_eic <- featureChromatograms(ftms, features = fid_other_features)
+
+par(mfrow = c(2, 1))
+plot(fid_eic)
+grid()
+abline(v = rtime(fid_ms2), col = "blue")
+abline(v = rtime(ms2)[ms2_id %in% fid_ms2_mult], col = "red")
+
+plot(other_eic)
+grid()
+abline(v = rtime(fid_ms2), col = "blue")
+abline(v = rtime(ms2)[ms2_id %in% fid_ms2_mult], col = "red")
+```
+
+So, the two features seem overlapping on RT and *m/z* - it seems very odd that
+they were not combined in the same feature.
+
+Checking another example.
+
+### Example 2
+
+```{r}
+fid <- as.character(tmp$feature_id[3L])
+tab <- feature_summary_table(ftms, fid)
+pandoc.table(tab, style = "rmarkdown", split.table = Inf)
+```
+
+Next we evaluate whether the current feature shared chromatographic peaks with
+any other feature:
+
+```{r}
+## are chrom peaks shared with other feature?
+shared_cpks <- shared_chrom_peaks(ftms, fid)
+shared_cpks
+```
+
+No chromatographic peaks are shared. Next we summarize the number of ambiguous
+MS2 spectra and the feature(s) with which they are shared.
+
+```{r, results = "asis"}
+#' Get all MS2 for the current feature
+fid_ms2 <- ms2[ms2$feature_id == fid]
+#' Get the ambiguous MS2 for current feature
+fid_ms2_mult <- intersect(ms2_mult, ms2_id[ms2$feature_id == fid])
+#' Get the other features for the ambiguous MS2 of current feature
+fid_other_features <- setdiff(ms2$feature_id[ms2_id %in% fid_ms2_mult], fid)
+
+tab <- data.frame(ms2_count = length(fid_ms2),
+                  ambiguous_ms2_count = length(fid_ms2_mult),
+                  other_feature = paste0(fid_other_features, collapse = ","))
+pandoc.table(tab, style = "rmarkdown", split.table = Inf)
+```
+
+A considerable number of MS2 spectra are shared with another feature. We next
+visually inspect their data, i.e., their EIC and the retention time where the
+unambiguous and ambiguous MS2 were detected.
+
+```{r}
+fid_eic <- featureChromatograms(ftms, features = fid)
+other_eic <- featureChromatograms(ftms, features = fid_other_features)
+
+par(mfrow = c(2, 1))
+plot(fid_eic)
+grid()
+abline(v = rtime(fid_ms2), col = "blue")
+abline(v = rtime(ms2)[ms2_id %in% fid_ms2_mult], col = "red")
+
+plot(other_eic)
+grid()
+abline(v = rtime(fid_ms2), col = "blue")
+abline(v = rtime(ms2)[ms2_id %in% fid_ms2_mult], col = "red")
+```
+
+There seems definitely to be some issue with peak detection and/or
+correspondence analysis. The retention times seem to clearly overlap. Thus we
+evaluate whether the m/z ranges of the associated chromatographic peaks are
+similar or different maybe explaining the observed separation.
+
+```{r}
+#' Getting the chromatographic peaks assigned to the first and to the
+#' second feature
+a <- chromPeaks(ftms)[featureDefinitions(ftms)[fid, "peakidx"][[1L]], ]
+b <- chromPeaks(ftms)[featureDefinitions(ftms)[
+                   fid_other_features, "peakidx"][[1L]], ]
+
+par(mfrow = c(1, 1))
+plot(1, 1, pch = NA, xlim = range(rbind(a, b)[, c("rtmin", "rtmax")]),
+     ylim = range(rbind(a, b)[, c("mzmin", "mzmax")]))
+grid()
+rect(xleft = a[, "rtmin"], xright = a[, "rtmax"],
+     ybottom = a[, "mzmin"], ytop = a[, "mzmax"], border = "#ff000080")
+rect(xleft = b[, "rtmin"], xright = b[, "rtmax"],
+     ybottom = b[, "mzmin"], ytop = b[, "mzmax"], border = "#0000ff80", lty = 2)
+```
+
+There seems no explanation why these chrom peaks are not grouped into the same
+feature. Thus, this seems to be a problem with the correspondence analysis.
+
+Note: on second look.
+
+```{r}
+#' Just to check if these are gap-filled
+chromPeakData(ftms)[featureDefinitions(ftms)[fid, "peakidx"][[1L]], "is_filled"]
+#' so, yes, there are gap-filled peaks that are overlapping.
+```
+
+Need to understand why these chrom peaks were grouped into different
+features. Extracting the EIC for this m/z slice.
+
+```{r}
+#' Define the m/z range of the present features
+mzr <- range(c(a[, c("mzmin", "mzmax")], b[, c("mzmin", "mzmax")]))
+#' Get rid of gap-filled chromatographic peaks - we don't have/want them
+#' for correspondence analysis.
+ftms_mod <- dropFilledChromPeaks(ftms)
+
+#' Just to confirm - we extract again the chromatograophic peak areas, but
+#' this time it's just detected, no gap-filled peaks.
+a <- chromPeaks(ftms_mod)[featureDefinitions(ftms_mod)[fid, "peakidx"][[1L]], ]
+b <- chromPeaks(ftms_mod)[featureDefinitions(ftms_mod)[
+                   fid_other_features, "peakidx"][[1L]], ]
+par(mfrow = c(1, 1))
+plot(1, 1, pch = NA, xlim = range(rbind(a, b)[, c("rtmin", "rtmax")]),
+     ylim = range(rbind(a, b)[, c("mzmin", "mzmax")]))
+grid()
+rect(xleft = a[, "rtmin"], xright = a[, "rtmax"],
+     ybottom = a[, "mzmin"], ytop = a[, "mzmax"], border = "#ff000080")
+rect(xleft = b[, "rtmin"], xright = b[, "rtmax"],
+     ybottom = b[, "mzmin"], ytop = b[, "mzmax"], border = "#0000ff80", lty = 2)
+```
+
+So, indeed, the chromatographic peaks of the two features, even if we don't
+consider gap-filled peaks are overlapping in m/z and RT. So, we would expect
+that these get grouped into the same feature. We next show the results from the
+correspondence analysis for the m/z slice:
+
+```{r}
+eic <- chromatogram(ftms_mod, mz = mzr, rt = c(430, 520))
+plotChromPeakDensity(eic)
+```
+
+Indeed, two separate features were identified - apparently based on the RT of
+their peak apex. In this case, we should increase the value for the `bw`
+parameter of `PeakDensityParam`.
+
+```{r}
+#' Use the same setting as for the preprocessing, but increase `bw` from 2 to 3.
+pdp <- PeakDensityParam(sampleGroups = sampleData(ftms)$sample_id,
+                        bw = 4, minFraction = 0.3, binSize = 0.1,
+                        ppm = 10)
+plotChromPeakDensity(eic, simulate = TRUE, param = pdp)
+
+```
+
+Evaluating another feature.
+
+### Example 3
+
+```{r}
+fid <- as.character(tmp$feature_id[5L])
+tab <- feature_summary_table(ftms, fid)
+pandoc.table(tab, style = "rmarkdown", split.table = Inf)
+```
+
+Next we evaluate whether the current feature shared chromatographic peaks with
+any other feature:
+
+```{r}
+## are chrom peaks shared with other feature?
+shared_cpks <- shared_chrom_peaks(ftms, fid)
+shared_cpks
+```
+
+No chromatographic peaks are shared. Next we summarize the number of ambiguous
+MS2 spectra and the feature(s) with which they are shared.
+
+```{r, results = "asis"}
+#' Get all MS2 for the current feature
+fid_ms2 <- ms2[ms2$feature_id == fid]
+#' Get the ambiguous MS2 for current feature
+fid_ms2_mult <- intersect(ms2_mult, ms2_id[ms2$feature_id == fid])
+#' Get the other features for the ambiguous MS2 of current feature
+fid_other_features <- setdiff(ms2$feature_id[ms2_id %in% fid_ms2_mult], fid)
+
+tab <- data.frame(ms2_count = length(fid_ms2),
+                  ambiguous_ms2_count = length(fid_ms2_mult),
+                  other_feature = paste0(fid_other_features, collapse = ","))
+pandoc.table(tab, style = "rmarkdown", split.table = Inf)
+```
+
+A considerable number of MS2 spectra are shared with another feature. We next
+visually inspect their data, i.e., their EIC and the retention time where the
+unambiguous and ambiguous MS2 were detected.
+
+```{r}
+fid_eic <- featureChromatograms(ftms, features = fid)
+other_eic <- featureChromatograms(ftms, features = fid_other_features)
+
+par(mfrow = c(2, 1))
+plot(fid_eic)
+grid()
+abline(v = rtime(fid_ms2), col = "blue")
+abline(v = rtime(ms2)[ms2_id %in% fid_ms2_mult], col = "red")
+
+plot(other_eic)
+grid()
+abline(v = rtime(fid_ms2), col = "blue")
+abline(v = rtime(ms2)[ms2_id %in% fid_ms2_mult], col = "red")
+```
+
+There seems definitely to be some issue with peak detection and/or
+correspondence analysis. The retention times seem to clearly overlap. Thus we
+evaluate whether the m/z ranges of the associated chromatographic peaks are
+similar or different maybe explaining the observed separation.
+
+```{r}
+a <- chromPeaks(ftms)[featureDefinitions(ftms)[fid, "peakidx"][[1L]], ]
+b <- chromPeaks(ftms)[featureDefinitions(ftms)[
+                   fid_other_features, "peakidx"][[1L]], ]
+
+plot(1, 1, pch = NA, xlim = range(rbind(a, b)[, c("rtmin", "rtmax")]),
+     ylim = range(rbind(a, b)[, c("mzmin", "mzmax")]))
+grid()
+rect(xleft = a[, "rtmin"], xright = a[, "rtmax"],
+     ybottom = a[, "mzmin"], ytop = a[, "mzmax"], border = "#ff000080")
+rect(xleft = b[, "rtmin"], xright = b[, "rtmax"],
+     ybottom = b[, "mzmin"], ytop = b[, "mzmax"], border = "#0000ff80", lty = 2)
+```
+
+Similar to the previous example, there is absolutely no reason these chrom peaks
+are not part of the same feature! Again, most of the peaks are gap-filled. We
+plot the peak area again without gap-filled peaks.
+
+```{r}
+a <- chromPeaks(ftms_mod)[featureDefinitions(ftms_mod)[fid, "peakidx"][[1L]], ]
+b <- chromPeaks(ftms_mod)[featureDefinitions(ftms_mod)[
+                   fid_other_features, "peakidx"][[1L]], ]
+par(mfrow = c(1, 1))
+plot(1, 1, pch = NA, xlim = range(rbind(a, b)[, c("rtmin", "rtmax")]),
+     ylim = range(rbind(a, b)[, c("mzmin", "mzmax")]))
+grid()
+rect(xleft = a[, "rtmin"], xright = a[, "rtmax"],
+     ybottom = a[, "mzmin"], ytop = a[, "mzmax"], border = "#ff000080")
+rect(xleft = b[, "rtmin"], xright = b[, "rtmax"],
+     ybottom = b[, "mzmin"], ytop = b[, "mzmax"], border = "#0000ff80", lty = 2)
+
+```
+
+Here it becomes quite obvious that different features were defined, as there is
+some difference in RT between the peak areas. We next evaluate the results from
+the correspondence.
+
+```{r}
+mzr <- range(c(a[, c("mzmin", "mzmax")], b[, c("mzmin", "mzmax")]))
+eic <- chromatogram(ftms_mod, mz = mzr, rt = c(2800, 2990))
+plotChromPeakDensity(eic)
+```
+
+Indeed, different features were identified - apparently based on the RT of
+their peak apex. In this case, we should increase the value for the `bw`
+parameter of `PeakDensityParam`. Increasing the `bw` parameter will not help in
+this case, because there are only few, sparse peaks detected in the individual
+samples. Maybe increasing the `minFraction` might help?
+
+```{r}
+#' Use the same setting as for the preprocessing, but increase `bw` from 2 to 3.
+pdp <- PeakDensityParam(sampleGroups = sampleData(ftms)$sample_id,
+                        bw = 3, minFraction = 0.5, binSize = 0.1,
+                        ppm = 10)
+plotChromPeakDensity(eic, simulate = TRUE, param = pdp)
+
+```
+
+
+### Example 4
+
+```{r}
+fid <- as.character(tmp$feature_id[7L])
+tab <- feature_summary_table(ftms, fid)
+pandoc.table(tab, style = "rmarkdown", split.table = Inf)
+```
+
+Next we evaluate whether the current feature shared chromatographic peaks with
+any other feature:
+
+```{r}
+## are chrom peaks shared with other feature?
+shared_cpks <- shared_chrom_peaks(ftms, fid)
+shared_cpks
+```
+
+No chromatographic peaks are shared. Next we summarize the number of ambiguous
+MS2 spectra and the feature(s) with which they are shared.
+
+```{r, results = "asis"}
+#' Get all MS2 for the current feature
+fid_ms2 <- ms2[ms2$feature_id == fid]
+#' Get the ambiguous MS2 for current feature
+fid_ms2_mult <- intersect(ms2_mult, ms2_id[ms2$feature_id == fid])
+#' Get the other features for the ambiguous MS2 of current feature
+fid_other_features <- setdiff(ms2$feature_id[ms2_id %in% fid_ms2_mult], fid)
+
+tab <- data.frame(ms2_count = length(fid_ms2),
+                  ambiguous_ms2_count = length(fid_ms2_mult),
+                  other_feature = paste0(fid_other_features, collapse = ","))
+pandoc.table(tab, style = "rmarkdown", split.table = Inf)
+```
+
+A considerable number of MS2 spectra are shared with another feature. We next
+visually inspect their data, i.e., their EIC and the retention time where the
+unambiguous and ambiguous MS2 were detected.
+
+```{r}
+fid_eic <- featureChromatograms(ftms, features = fid)
+other_eic <- featureChromatograms(ftms, features = fid_other_features)
+
+par(mfrow = c(2, 1))
+plot(fid_eic)
+grid()
+abline(v = rtime(fid_ms2), col = "blue")
+abline(v = rtime(ms2)[ms2_id %in% fid_ms2_mult], col = "red")
+
+plot(other_eic)
+grid()
+abline(v = rtime(fid_ms2), col = "blue")
+abline(v = rtime(ms2)[ms2_id %in% fid_ms2_mult], col = "red")
+```
+
+There seems definitely to be some issue with peak detection and/or
+correspondence analysis. The retention times seem to clearly overlap. Thus we
+evaluate whether the m/z ranges of the associated chromatographic peaks are
+similar or different maybe explaining the observed separation.
+
+```{r}
+a <- chromPeaks(ftms)[featureDefinitions(ftms)[fid, "peakidx"][[1L]], ]
+b <- chromPeaks(ftms)[featureDefinitions(ftms)[
+                   fid_other_features, "peakidx"][[1L]], ]
+
+plot(1, 1, pch = NA, xlim = range(rbind(a, b)[, c("rtmin", "rtmax")]),
+     ylim = range(rbind(a, b)[, c("mzmin", "mzmax")]))
+grid()
+rect(xleft = a[, "rtmin"], xright = a[, "rtmax"],
+     ybottom = a[, "mzmin"], ytop = a[, "mzmax"], border = "#ff000080")
+rect(xleft = b[, "rtmin"], xright = b[, "rtmax"],
+     ybottom = b[, "mzmin"], ytop = b[, "mzmax"], border = "#0000ff80")
+```
+
+
+```{r}
+```
+
+
+Now proceeding with the previous code.
+
 
 Manually evaluate some of these cases:
 

--- a/ftms_xcms_short.qmd
+++ b/ftms_xcms_short.qmd
@@ -140,14 +140,13 @@ ftms <- refineChromPeaks(ftms, mnpp)
 ```
 
 Here we add *CleanPeaksParam* to remove chromatographic peaks with a retention
-time range larger than the provided maximal acceptable width (maxPeakwidth) 
+time range larger than the provided maximal acceptable width (maxPeakwidth)
 based on 75th percentile of peak widths * 3.
 
 ```{r}
 cpp <- CleanPeaksParam(maxPeakwidth = 80)
 ftms <- refineChromPeaks(ftms, cpp)
 ```
-
 
 
 We evaluate the number of peaks and the observed peak widths also after

--- a/ftms_xcms_short.qmd
+++ b/ftms_xcms_short.qmd
@@ -189,7 +189,7 @@ We can see from the plot above that there is one sample that has been
 largely adjusted, so it goes up to 15 seconds.
 
 
-We continue the preprocessing with the final correspondence analysis. 
+We continue the preprocessing with the final correspondence analysis.
 We adapt now the settings, in particular
 the bw parameter, that can be much stricter because of the properly
 aligned data set. Again, we test the settings on the extracted ion


### PR DESCRIPTION
This PR adds a section with manual evaluation of the signal for duplicated/ambiguous MS2 spectra. In detail, it evaluates the chromatographi peak area (mz - RT) for each chromatograpic peak of a features.

My conclusion from this is that some duplicated assignments can be attributed to the correspondence step in which the features are defined. In most of the cases I checked, the duplicated MS2 are assigned to features that have the same m/z range and also partially overlapping RT range. We could maybe some of these fix with changing the correspondence setting, i.e. increasing the `bw` from the `PeakDensityParam`. The figures is from "Example 2" of the quarto document:

### Example 2

This are the EICs for the two features that share 8 (!) MS2 spectra:

<img width="480" height="480" alt="group-1-eics" src="https://github.com/user-attachments/assets/109875df-5b26-48a6-bb25-ba886e814b0e" />

their m/z range is essentially overlapping, and also on RT they seem to be overlapping. The RT when the MS2 were measured are indicated with the vertical lines, blue for MS2 that are specific for a feature, and red for the ambiguous MS2.

Now, why are these two different features you might ask. Also by looking at the *chrom peak area* (the m/z - RT region of each chromatographic peaks) of all chromatographic peaks assigned to these two features it looks like they should in fact be a single feature:

<img width="480" height="480" alt="group-1-peak-area" src="https://github.com/user-attachments/assets/36f3db16-173b-44db-bb7b-9da8844252b2" />

red and blue rectangles represent the peak area of the individual chrom peaks for the first and second feature, respectively. They are clearly overlapping in both m/z and RT. To understand **why** they have been grouped into separate features I next extracted the EIC for the m/z range and RT range containing both features:

<img width="480" height="480" alt="group-1-correspondence-results" src="https://github.com/user-attachments/assets/c213aab0-6424-4d80-8a96-881f70b2dfd3" />

here, the upper part of the plot shows the EIC signal in that region, and the lower part the defined chromatographic peaks, each point is the apex position of a chromatographic peak, and the chromatographic peaks grouped into the same feature are indicated with grey rectangles. So, here we see that in 4 samples the RT of the apex is a bit shifted to the right. and with our settings, in particular the `bw = 2`, the peaks get grouped into **separate** features. Increasing the `bw` to 3 or 4 would solve the issue **for this example**:

<img width="480" height="480" alt="group-1-correspondence-bw3" src="https://github.com/user-attachments/assets/73e5d1d7-5a61-4860-b8e9-1f85eed7d4ab" />

so, there would be just one feature defined, not two.

So, 1), I would suggest to re-run the preprocessing setting `bw = 4` for `PeakDensityParam` and then check again what problematic/duplicated MS2 assignments we have.

We will definitely **not** fix Example 3 below

### Example 3 

<img width="480" height="480" alt="group-2-eics" src="https://github.com/user-attachments/assets/2e5eefc6-e852-4a3d-85aa-6f073a0559f1" />

In this case I would actually question whether this is really a feature respectively valid signal for a compound, or is just some (e.g. salt) contamination?


### Other thoughts

A final thought: the actual problem from e.g. the example 2 above is that in these particular cases we seem to have features with chromatographic peaks that are overlapping on m/z and retention time (within the **same** sample). I was actually wondering where they are coming from, because we run `refineChromPeaks()` with the `MergeNeighboringPeaksParam`, that should eventually merge them. And in fact, they are introduced (at least in the example above) by the **gap-filling** task. In Example 2 above, a chromatographic peak for feature 2 was only identified in 4 samples - in the other 6 samples a chromatographic peak was identified, but these were assigned to the feature 1 with just a bit smaller RT. Now, the gap-filling will add chromatographic peaks for a feature in all samples in which no chromatographic peak was identified. This created in the present example the chromatographic peaks overlapping in RT and m/z. And that would again explain the duplicated MS2 assignment - because, it can **only** (or mostly) happen if we have gap-filled chrom peaks.

I still have to rethink this last comment above - but happy for any thoughts and ideas on these findings @rebdau and @Ahlammentag 

For @Ahlammentag , as mentioned above, I would suggest to rerun preprocessing with `bw = 4` and then check if there are still some duplicated assignments. we can then maybe look into these and discuss how/if to fix.