### PR TITLE
added filter chromPeaks based on Gauss shape

### DIFF
--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -41,7 +41,7 @@ First we load the `XcmsExperiment` ftms object with the preprocessing
 results.
 
 ```{r}
-load(file.path(pth, "data", "ftms_fill.RData"))
+load(file.path(pth, "data", "ftms_fill_filtergauss.RData"))
 class(ftms)
 ```
 
@@ -84,9 +84,8 @@ table(msLevel(s))
 
 
 
-In total, there were 20904 MS2 spectra. This means that 91.10% of the MS2
-spectra ((20904-1860)\*100/20904) could not be assigned to any
-chromatographic peak.
+In total, there were `r table(msLevel(s))[2]` MS2 spectra. This means that `r round((table(msLevel(s))[2]-length(ms2$feature_id))*100/table(msLevel(s))[2], 1)` % of the MS2
+spectra could not be assigned to any chromatographic peak.
 
 The percentage of features with at least one MS2:
 
@@ -278,40 +277,22 @@ spectraVariables(ftms_msn_tree)
 length(unique(ftms_msn_tree$MSntreeID))
 ```
 
-for in total `r length(unique(ftms_msn_tree$feature_id))` features. The
+There are in total `r length(unique(ftms_msn_tree$MSntreeID))` spectral (fragmentation) trees for in total `r length(unique(ftms_msn_tree$feature_id))` features. The
 distribution of the lengths of the fragmentation trees is
 
 ```{r}
 ftms_msn_tree$MSntreeID |>
     table() |>
     quantile()
+
+table(table(ftms_msn_tree$MSntreeID))
 ```
 
-There is apparently (at least) one tree with 4 spectra. Extracting this
-particular MSn tree.
+Fragmentation trees have maximally 4 spectra. 
+This is in accordance with the setup of the ion trap instrument: The two most intense first order product ions were refragmented (if their intensity was above a threshold), resulting in maximally two MS3 spectra, and the most intense second order product ion of the most intense first order product ion was also refragmented (if it's intensity was above a threshold), resulting in maximally one MS4 spectrum.
+So, a fragmentation tree can maximally consist of one MS2 spectrum + two MS3 spectra + one MS4 spectrum = four spectra.
 
-```{r}
-max_index <- ftms_msn_tree$MSntreeID |>
-    table() |>
-    as.integer() |>
-    which.max()
 
-max_tree <- ftms_msn_tree[ftms_msn_tree$MSntreeID == max_index]
-max_tree$rtime
-max_tree$msLevel
-max_tree$precScanNum
-max_tree$scanIndex
-max_tree$acquisitionNum
-max_tree$dataOrigin
-max_tree$feature_id
-max_tree$MSntreeID
-```
-
-The MSntree with maximum number of spectra corresponds to the tree,
-within dataOrigin S1R1, depending on MS2 with ScanIndex 2182 which was
-assigned to one FeatureID: FT1254 Within dataOrigin S1R1, scanIndex 2183
-(MS3), 2184 (MS3), and 2185 (MS4) are assigned to a single feature:
-FT1254.
 
 ```{r}
 ## we stored the tree ids and the msLevels to a dataframe
@@ -325,13 +306,13 @@ max_level_per_tree <- df %>%
   summarise(max_level = max(msLevel), .groups = "drop")
 
 
-table(max_level_per_tree$max_level)
+print(t <- table(max_level_per_tree$max_level))
 
 ```
 
-The number of trees that go up to MS2 level is : 503 The number of
-trees that go up to MS3 level is : 377 The number of trees that go up to
-MS4 level is : 980
+The number of trees that go up to MS2 level is : `r t[1]`. The number of
+trees that go up to MS3 level is : `r t[2]`. The number of trees that go up to
+MS4 level is : `r t[3]`.
 
 Next we select one most representative tree per feature based on the
 longest one and if we have many, we select one tree with the highest MS2

--- a/ftms_xcms_short.qmd
+++ b/ftms_xcms_short.qmd
@@ -128,25 +128,7 @@ quantile(unname(pks[, "rtmax"] - pks[, "rtmin"]))
 quantile(unname(pks[, "mzmax"] - pks[, "mzmin"]))
 ```
 
-
-`chromPeakSummary(ftms)` calculates extra peak shape descriptors, including beta_cor. 
-`beta_cor` is the correlation coefficient between the extracted ion chromatogram (EIC) peak and an idealized Gaussian peak fitted to it.
-We can use this peak shape descriptor to filter out junk peaks. 
-Here, we first look at the distribution of beta_cor:
-
 ```{r}
-beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
-colnames(beta_metrics)
-summary(beta_metrics[, "beta_cor"])
-
-hist(beta_metrics[, "beta_cor"], breaks = 50, main = "Distribution of beta_cor", xlab = "beta_cor")
-
-
-
-```
-
-`beta_cor` ranges from -1.0 to 1.0 and has median `summary(beta_metrics[, "beta_cor"])[3]`. Most peaks thus have a `beta-cor`close to 1. 
-Negative beta_cor values indicate anti-correlation of observed signal with Gaussian-like model. These peaks seem to have a valley instead of an apex, maybe multiple shoulders or just baseline fluctuation. Peaks with **negative beta_cor must be filtered out**. But we could first refine the peaks and evaluate the beta_cor values again after refinement before filtering.
 
 We next perform the **chromatographic peak refinement** to reduce the
 number of potential centWave-specific peak detection artifacts. We
@@ -157,12 +139,8 @@ of the observed median widths).
 mnpp <- MergeNeighboringPeaksParam(expandRt = 10, expandMz = 0.001,
                                    minProp = 0.66)
 ftms <- refineChromPeaks(ftms, mnpp)
-
-beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
-summary(beta_metrics[, "beta_cor"])
-hist(beta_metrics[, "beta_cor"], breaks = 50, main = "Distribution of beta_cor", xlab = "beta_cor")
 ```
-The median `beta_cor` value increased slightly: `summary(beta_metrics[, "beta_cor"])[3]`. 
+
 Here we add *CleanPeaksParam* to remove chromatographic peaks with a retention
 time range larger than the provided maximal acceptable width (maxPeakwidth)
 based on (75th percentile of peak widths) * 3.
@@ -170,13 +148,7 @@ based on (75th percentile of peak widths) * 3.
 ```{r}
 cpp <- CleanPeaksParam(maxPeakwidth = 80)
 ftms <- refineChromPeaks(ftms, cpp)
-
-beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
-summary(beta_metrics[, "beta_cor"])
-hist(beta_metrics[, "beta_cor"], breaks = 50, main = "Distribution of beta_cor", xlab = "beta_cor")
 ```
-Again, the median `beta_cor` value increased slightly: `summary(beta_metrics[, "beta_cor"])[3]`, indicating that a larger fraction of the peaks have a good peak shape.
-
 
 We evaluate the number of peaks and the observed peak widths also after
 refinement.
@@ -187,20 +159,95 @@ nrow(pks)
 table(pks[, "sample"])
 quantile(unname(pks[,"rtmax"] - pks[,"rtmin"]))
 quantile(unname(pks[,"mzmax"] - pks[,"mzmin"]))
-
 ```
-Now we want to filter out junk peaks based on `beta_cor < 0`.
+
+At last we calculate chromatographic peak quality metrics using the
+`chromPeakSummary()` function with the `BetaDistributionParam()`. This resulting
+extra peak shape descriptors, including *beta_cor* can then be used to filter
+low quality peaks. *beta_cor* is the correlation coefficient between the
+extracted ion chromatogram (EIC) peak and an idealized Gaussian peak fitted to
+it. We can use this peak shape descriptor to filter out junk peaks. Here, we
+first look at the distribution of beta_cor:
 
 ```{r}
-beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
-keep_idx <- (beta_metrics[, "beta_cor"] > 0)
-filtered_pks <- pks[keep_idx, ]
-chromPeaks(ftms) <- filtered_pks
+beta_metrics <- chromPeakSummary(ftms, param = BetaDistributionParam())
+colnames(beta_metrics)
+summary(beta_metrics[, "beta_cor"])
 
+hist(beta_metrics[, "beta_cor"], breaks = 50,
+     main = "Distribution of beta_cor", xlab = "beta_cor")
+```
+
+`beta_cor` ranges from -1.0 to 1.0 and has median
+`r median(beta_metrics[, "beta_cor"], na.rm = TRUE)`.
+Most peaks thus have a `beta-cor`close to 1. Negative beta_cor
+values indicate anti-correlation of observed signal with Gaussian-like
+model. These peaks seem to have a valley instead of an apex, maybe multiple
+shoulders or just baseline fluctuation. Peaks with **negative beta_cor must be
+filtered out**. But we could first refine the peaks and evaluate the beta_cor
+values again after refinement before filtering.
+
+```{r}
+#' silently plotting and saving examples for good, intermediate and bad quality
+set.seed(123)
+#' Selecting 12 random peaks with a negative beta_cor
+cid <- rownames(beta_metrics)[which(beta_metrics[, "beta_cor"] < -0.5)] |>
+    sample(size = 12)
+eics <- chromPeakChromatograms(ftms, peaks = cid)
+#' Saving the EICs to a file
+dr <- file.path("images", "chrom_peak_evaluation")
+dir.create(dr, recursive = TRUE, showWarnings = FALSE)
+png(filename = file.path(dr, "chrom_peaks_negative_beta_cor.png"),
+    width = 15, height = 15, units = "cm", res = 600, pointsize = 6)
+plot(eics)
+dev.off()
+
+#' Selecting 12 random peaks with beta_cor around 0
+cid <- rownames(beta_metrics)[which(beta_metrics[, "beta_cor"] > -0.2 &
+                                    beta_metrics[, "beta_cor"] < 0.2)] |>
+    sample(size = 12)
+eics <- chromPeakChromatograms(ftms, peaks = cid)
+#' Saving the EICs to a file
+png(filename = file.path(dr, "chrom_peaks_0_beta_cor.png"),
+    width = 15, height = 15, units = "cm", res = 600, pointsize = 6)
+plot(eics)
+dev.off()
+
+#' Selecting 12 random peaks with beta_cor around 1
+cid <- rownames(beta_metrics)[which(beta_metrics[, "beta_cor"] > 0.9)] |>
+    sample(size = 12)
+eics <- chromPeakChromatograms(ftms, peaks = cid)
+#' Saving the EICs to a file
+png(filename = file.path(dr, "chrom_peaks_1_beta_cor.png"),
+    width = 15, height = 15, units = "cm", res = 600, pointsize = 6)
+plot(eics)
+dev.off()
+
+#' Selecting 12 peaks with a NA beta cor
+cid <- rownames(beta_metrics)[is.na(beta_metrics[, "beta_cor"])] |>
+    sample(size = 12)
+eics <- chromPeakChromatograms(ftms, peaks = cid)
+#' Saving the EICs to a file
+png(filename = file.path(dr, "chrom_peaks_NA_beta_cor.png"),
+    width = 15, height = 15, units = "cm", res = 600, pointsize = 6)
+plot(eics)
+dev.off()
 
 ```
 
-We evaluate the number of peaks and the observed peak widths and shapes.
+Now we want to filter out junk peaks based on `beta_cor < 0`. This will remove
+`r length(which(beta_metrics[, "beta_cor"] < 0))` peaks with a negative beta
+correlation and `r sum(is.na(beta_metrics[, "beta_cor"]))` peaks with a missing
+beta correlation value of the in total
+`r nrow(beta_metrics)` chromatographic peaks.
+
+```{r}
+#' Keep only chrom peaks with a positive correlation, removing also those
+#' with a missing value.
+ftms <- filterChromPeaks(ftms, keep = which(beta_metrics[, "beta_cor"] > 0))
+```
+
+We evaluate the number of peaks and the observed peak widths.
 
 ```{r}
 pks <- chromPeaks(ftms)
@@ -209,10 +256,8 @@ table(pks[, "sample"])
 quantile(unname(pks[,"rtmax"] - pks[,"rtmin"]))
 quantile(unname(pks[,"mzmax"] - pks[,"mzmin"]))
 
-beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
-summary(beta_metrics[, "beta_cor"])
-hist(beta_metrics[, "beta_cor"], breaks = 50, main = "Distribution of beta_cor", xlab = "beta_cor")
 ```
+
 ## Retention time alignment
 
 We next perform an initial correspondence analysis that is needed for

--- a/ftms_xcms_short.qmd
+++ b/ftms_xcms_short.qmd
@@ -128,6 +128,26 @@ quantile(unname(pks[, "rtmax"] - pks[, "rtmin"]))
 quantile(unname(pks[, "mzmax"] - pks[, "mzmin"]))
 ```
 
+
+`chromPeakSummary(ftms)` calculates extra peak shape descriptors, including beta_cor. 
+`beta_cor` is the correlation coefficient between the extracted ion chromatogram (EIC) peak and an idealized Gaussian peak fitted to it.
+We can use this peak shape descriptor to filter out junk peaks. 
+Here, we first look at the distribution of beta_cor:
+
+```{r}
+beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
+colnames(beta_metrics)
+summary(beta_metrics[, "beta_cor"])
+
+hist(beta_metrics[, "beta_cor"], breaks = 50, main = "Distribution of beta_cor", xlab = "beta_cor")
+
+
+
+```
+
+`beta_cor` ranges from -1.0 to 1.0 and has median `summary(beta_metrics[, "beta_cor"])[3]`. Most peaks thus have a `beta-cor`close to 1. 
+Negative beta_cor values indicate anti-correlation of observed signal with Gaussian-like model. These peaks seem to have a valley instead of an apex, maybe multiple shoulders or just baseline fluctuation. Peaks with **negative beta_cor must be filtered out**. But we could first refine the peaks and evaluate the beta_cor values again after refinement before filtering.
+
 We next perform the **chromatographic peak refinement** to reduce the
 number of potential centWave-specific peak detection artifacts. We
 choose settings that depend on the observed peak widths above (i.e., about half
@@ -137,16 +157,25 @@ of the observed median widths).
 mnpp <- MergeNeighboringPeaksParam(expandRt = 10, expandMz = 0.001,
                                    minProp = 0.66)
 ftms <- refineChromPeaks(ftms, mnpp)
-```
 
+beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
+summary(beta_metrics[, "beta_cor"])
+hist(beta_metrics[, "beta_cor"], breaks = 50, main = "Distribution of beta_cor", xlab = "beta_cor")
+```
+The median `beta_cor` value increased slightly: `summary(beta_metrics[, "beta_cor"])[3]`. 
 Here we add *CleanPeaksParam* to remove chromatographic peaks with a retention
 time range larger than the provided maximal acceptable width (maxPeakwidth)
-based on 75th percentile of peak widths * 3.
+based on (75th percentile of peak widths) * 3.
 
 ```{r}
 cpp <- CleanPeaksParam(maxPeakwidth = 80)
 ftms <- refineChromPeaks(ftms, cpp)
+
+beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
+summary(beta_metrics[, "beta_cor"])
+hist(beta_metrics[, "beta_cor"], breaks = 50, main = "Distribution of beta_cor", xlab = "beta_cor")
 ```
+Again, the median `beta_cor` value increased slightly: `summary(beta_metrics[, "beta_cor"])[3]`, indicating that a larger fraction of the peaks have a good peak shape.
 
 
 We evaluate the number of peaks and the observed peak widths also after
@@ -158,8 +187,32 @@ nrow(pks)
 table(pks[, "sample"])
 quantile(unname(pks[,"rtmax"] - pks[,"rtmin"]))
 quantile(unname(pks[,"mzmax"] - pks[,"mzmin"]))
+
+```
+Now we want to filter out junk peaks based on `beta_cor < 0`.
+
+```{r}
+beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
+keep_idx <- (beta_metrics[, "beta_cor"] > 0)
+filtered_pks <- pks[keep_idx, ]
+chromPeaks(ftms) <- filtered_pks
+
+
 ```
 
+We evaluate the number of peaks and the observed peak widths and shapes.
+
+```{r}
+pks <- chromPeaks(ftms)
+nrow(pks)
+table(pks[, "sample"])
+quantile(unname(pks[,"rtmax"] - pks[,"rtmin"]))
+quantile(unname(pks[,"mzmax"] - pks[,"mzmin"]))
+
+beta_metrics <- chromPeakSummary(ftms, param=BetaDistributionParam())
+summary(beta_metrics[, "beta_cor"])
+hist(beta_metrics[, "beta_cor"], breaks = 50, main = "Distribution of beta_cor", xlab = "beta_cor")
+```
 ## Retention time alignment
 
 We next perform an initial correspondence analysis that is needed for

--- a/ftms_xcms_short.qmd
+++ b/ftms_xcms_short.qmd
@@ -128,8 +128,6 @@ quantile(unname(pks[, "rtmax"] - pks[, "rtmin"]))
 quantile(unname(pks[, "mzmax"] - pks[, "mzmin"]))
 ```
 
-```{r}
-
 We next perform the **chromatographic peak refinement** to reduce the
 number of potential centWave-specific peak detection artifacts. We
 choose settings that depend on the observed peak widths above (i.e., about half


### PR DESCRIPTION
In `ftms_xcms_short.qmd`, I filtered out peaks based on the fit with a gaussian shape.
In `ftms_filtering.qmd`, I updated the input .RData. The number of features to which spectra were assigned only decreased slightly, which is good (I don't have the exact numbers). 
Trees have maximally 4 spectra. I removed a chunk of code that was inspecting trees with too many spectra.
I did some minor edits to have inline r code to replace text that was not updated.
All looks good to me now.