### PR TITLE
Centroiding just MS1 data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ This folder contains the following files:
 1. *centroiding.qmd*
 2. *ftms_preprocessing.qmd*
 3. *ftms_filtering.qmd*
+4. *ftms_assembled.qmd*
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This folder contains the following files:
 - [ftms_filtering.qmd](ftms_filtering.qmd): in this file we filter the ftms data
   to keep one tree per feature.
 
+- https://github.com/rebdau/RDynLib_ftms/blob/ahlam/ftms_assembled.qmd : In this quarto document
+ we create an assembled MS/MS data from ftms object that contains one tree per feature create
+ in the [ftms_filtering.qmd](ftms_filtering.qmd) file.
 **The execution order:**
 
 1. *centroiding.qmd*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This folder contains the following files:
 
 - [ftms_filtering.qmd](ftms_filtering.qmd): in this file we filter the ftms data
   to keep one tree per feature.
+
+- [ftms_assembled.qmd](https://github.com/rebdau/RDynLib_ftms/blob/ahlam/ftms_assembled.qmd) : In this quarto document
+ we create an assembled MS/MS data from ftms object that contains one tree per feature create
+ in the ftms_filtering.qmd file.
   
 **The execution order:**
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This folder contains the following files:
   to keep one tree per feature.
 
 - [ftms_assembled.qmd](https://github.com/rebdau/RDynLib_ftms/blob/ahlam/ftms_assembled.qmd) : In this quarto document
- we create an assembled MS/MS data from ftms object that contains one tree per feature create
- in the ftms_filtering.qmd file.
+ we create an assembled MS/MS data from ftms object that contains one tree
+ per feature created in the ftms_filtering.qmd file.
   
 **The execution order:**
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ This folder contains the following files:
 
 - [ftms_filtering.qmd](ftms_filtering.qmd): in this file we filter the ftms data
   to keep one tree per feature.
-
-- https://github.com/rebdau/RDynLib_ftms/blob/ahlam/ftms_assembled.qmd : In this quarto document
- we create an assembled MS/MS data from ftms object that contains one tree per feature create
- in the [ftms_filtering.qmd](ftms_filtering.qmd) file.
+  
 **The execution order:**
 
 1. *centroiding.qmd*

--- a/centroiding.qmd
+++ b/centroiding.qmd
@@ -24,6 +24,7 @@ library(readxl)
 library(dplyr)
 library(readr)
 library(purrr)
+
 ```
 
 We use the *Spectra* package, in particular its `pickPeaks()` function to perform the centroiding. We perform the analysis separately for each original mzXML file and export the data directly to a file in mzML format.
@@ -33,7 +34,7 @@ We use the *Spectra* package, in particular its `pickPeaks()` function to perfor
 #' and the path where we want to export the centroided mzML data.
 pth <- getwd()
 MZXML_PATH <- file.path(pth,"data","mzXML")
-MZML_PATH <- file.path(pth,"data","mzML")
+MZML_PATH <- file.path(pth,"data","mzML_cent1")
 
 #' List all files
 fls <- dir(MZXML_PATH, full.name = TRUE)
@@ -57,7 +58,7 @@ In profile-mode data, each mass peak is represented by a distribution of signal.
 
 ```{r}
 
-a_c <- pickPeaks(a, halfWindowSize = 10L, k = 2L, threshold = 0.33)
+a_c <-Spectra::pickPeaks(a, halfWindowSize = 10L, k = 2L, threshold = 0.33)
 
 par(mfrow = c(2, 2))
 plotSpectra(a)
@@ -93,83 +94,42 @@ We proceed now and centroid all data files with the settings above.
 if (!dir.exists(MZML_PATH))
     dir.create(MZML_PATH, recursive = TRUE)
 
-for (f in fls) {
-    a <- Spectra(f)
-    fn <- file.path(MZML_PATH, sub("mzXML$", "mzML", basename(f)))
-    a <- pickPeaks(a, halfWindowSize = 10L, k = 2L, threshold = 0.33)
-    export(a, backend = MsBackendMzR(), file = fn,
-           format = "mzML", copy = TRUE)
-}
+library(BiocParallel)
+bpparam <- MulticoreParam(workers = 4)  
+
+bplapply(fls, function(f) {
+  message("Processing: ", basename(f))
+  a <- Spectra(f)
+  a <- setBackend(a, MsBackendMemory())
+  ms1 <- filterMsLevel(a, 1L)
+  msx <- filterMsLevel(a, 2:4)
+  ms1_cent <- Spectra::pickPeaks(ms1, halfWindowSize = 10L, k = 2L, threshold = 0.33)
+  ms1_cent <- applyProcessing(ms1_cent)
+  merged <- concatenateSpectra(list(ms1_cent, msx))
+  merged <- merged[order(rtime(merged))]
+  fn <- file.path(MZML_PATH, sub("\\.mzXML$", ".mzML", basename(f)))
+  export(merged, backend = MsBackendMzR(), file = fn, format = "mzML", copy = FALSE)
+}, BPPARAM = bpparam)
+
 
 b <- Spectra(fn)
+msLevel(b) |> table()
 all(centroided(b))
+
+
 all.equal(a$acquisitionNum, b$acquisitionNum)
 all.equal(a$precScanNum, b$precScanNum)
 all.equal(a$scanIndex, b$scanIndex)
 ```
 
 ```{r}
-sample_data_ftms <- read_xlsx(file.path(pth,"data","sample_data","ftms_data_files.xlsx")) |>
-    as.data.frame()
 
-ftms <- readMsExperiment(file.path(MZML_PATH, sample_data_ftms$data_file),
-                         sampleData = sample_data_ftms)
-ftms
 ```
 
-```{r}
-s <- spectra(ftms)
-spectraData(s)
+```{}
 ```
 
-```{r}
-# Create the read_csv_safely() function to safely read a delimited text file (CSV or TSV) into a data frame.
-# The function tries to use readr::read_delim() for speed and robustness,
-# and falls back to base::read.csv() if an error occurs.
-read_csv_safely <- function(file_path, sep = "\t", quote = "\"", header = TRUE, col_types = NULL) {
-  if (!file.exists(file_path)) {
-    stop(paste("The file does not exist:", file_path))
-  }
-  
-  tryCatch({
-    data <- read_delim(file_path, delim = sep, quote = quote, col_names = header, col_types = col_types)
-    return(as.data.frame(data))  
-  }, error = function(e) {
-    message("Error while reading with read_delim: ", e$message)
-    message("Trying read.csv...")
-    data <- read.csv(file_path, sep = sep, quote = quote, header = header, stringsAsFactors = FALSE)
-    return(as.data.frame(data))  
-  })
-}
-
-
-ms2_spectra_path <- "C:/Users/amentag/Desktop/these/Ahlam/these/RDynLib/database_QTOF_neg/CSV/MS2spectra.csv"
-col_types_spectra <- cols(
-  MS2PEAKLIST = col_character(),
-  MS2INTENSITYLIST = col_character()
-)
-
-ms2<- read_csv_safely(ms2_spectra_path, sep = "\t", col_types = col_types_spectra)
-
-head(ms2)
-```
-
-```{r}
-
-# Convert comma-separated strings into vectors and compare their lengths
-ms2$peaks_count <- sapply(strsplit(ms2$MS2PEAKLIST, ","), length)
-ms2$intensities_count <- sapply(strsplit(ms2$MS2INTENSITYLIST, ","), length)
-
-# Create a logical column indicating if counts match
-ms2$counts_match <- ms2$peaks_count == ms2$intensities_count
-
-# View summary
-table(ms2$counts_match)
-
-# Optionally, display mismatched rows
-ms2_mismatched <- ms2 %>% filter(!counts_match)
-head(ms2_mismatched)
-
+```{}
 ```
 
 # Questions and notes

--- a/centroiding.qmd
+++ b/centroiding.qmd
@@ -126,10 +126,10 @@ all.equal(a$scanIndex, b$scanIndex)
 
 ```
 
-```{}
+```         
 ```
 
-```{}
+```         
 ```
 
 # Questions and notes

--- a/ftms_assembled.qmd
+++ b/ftms_assembled.qmd
@@ -34,16 +34,16 @@ pth <- getwd()
 pth
 ```
 
-First we load the `Spectra` ftms object with one representative tree per
+First we load the `Spectra` ftms_one_tree object with one representative tree per
 feature.
 
 ```{r}
 load(file.path(pth, "data", "ftms_unique_tree.RData"))
 class(ftms_one_tree)
 ```
-
+## Preprocessing: round mz and remove duplicates
 Next we round `mz` values to the first integer using `round_perl()`
-function
+function and keep only the most intense peak if rounding results in duplicated mz.
 
 ```{r}
 round_perl <- function(number) {
@@ -52,7 +52,16 @@ round_perl <- function(number) {
 
 peaks_round_mz <- function(x, spectrumMsLevel, ...) {
     x[, 1L] <- round_perl(x[, 1L])
-    x
+    df <- as.data.frame(x)
+  colnames(df) <- c("mz", "intensity")
+  # Keep only highest intensity for duplicated mz
+  df <- df %>%
+    group_by(mz) %>%
+    slice_max(order_by = intensity, n = 1, with_ties = FALSE) %>%
+    arrange(mz)
+  # Return as matrix
+  as.matrix(df)
+
 }
 
 ftms_one_tree <- addProcessing(ftms_one_tree, peaks_round_mz)
@@ -60,23 +69,9 @@ ftms_one_tree <- addProcessing(ftms_one_tree, peaks_round_mz)
 
 ```
 
-keep only the most intense peak if the same mz is repeated in the same
-spectrum
 
-```{r}
-#'Clean a single spectrum
-#'keep only the most intense peak if the same mz is repeated
-clean_spectrum <- function(spectrum) {
-  as.data.frame(spectrum) %>%
-    group_by(mz) %>%
-    slice_max(order_by = intensity, n = 1, with_ties = FALSE) %>%
-    arrange(mz) %>%
-    as.matrix()
-}
-
-```
-
-Combine across levels (sum intensities if same mz)
+## Combine spectra from the same tree
+Create a function that takes a list of spectra (matrices), sums intensities for identical m/z values across spectra, and returns a merged spectrum.
 
 ```{r}
 #'Combine spectra across a tree
@@ -91,11 +86,15 @@ combine_spectra <- function(spectra_list) {
 }
 ```
 
+
+## Create assembled spectra object
+
 final function to create a new assembled spectra object
 
 ```{r}
 
 create_assembled_spectra <- function(ftms) {
+  #'ftms must be a spectra object
   #'Converting the backend to MsBackendMemory 
   #'so we could modify the peaksData
   ftms <- setBackend(ftms, MsBackendMemory())
@@ -103,51 +102,40 @@ create_assembled_spectra <- function(ftms) {
   pd_list <- peaksData(ftms)
   tree_ids <- unique(meta$MSntreeID)
   
-  assembled_list <- list()
+  assembled_list <- vector("list", length(tree_ids))
+  k <- 0
   
   for (tree_id in tree_ids) {
     idx <- which(meta$MSntreeID == tree_id)
     ms_levels <- meta$msLevel[idx]
     
-    #'First clean each spectrum individually 
-    #'(remove duplicate mz by keeping the max intensity)
-    cleaned_spectra <- lapply(pd_list[idx], clean_spectrum)
+    #'Use already preprocessed peaks 
+    spectra_list <- pd_list[idx]
     
-    #'If a tree has only MS2 level, we copy the MS2
-    #'row to the new spectra object as is it (after cleaning)
-    if (max(ms_levels) <= 2L) {
+    # Combine all spectra by summing intensities for matching m/z
+    merged_spec <- combine_spectra(spectra_list)
+    
+    # Use metadata from the first MS2 spectrum
       ms2_row <- idx[ms_levels == 2][1]
       ms2_meta <- meta[ms2_row, , drop = FALSE]
+      
+    # create new assembled spectrum
       df <- ms2_meta
       #'Mark it as assembled
       df$spectrum.type <- "assembled"
       df$MSntreeID <- tree_id
       #copy the same mz and intensity (already cleaned)
-      df$mz <- list(cleaned_spectra[[which(ms_levels == 2)[1]]][, "mz"])
-      df$intensity <- list(cleaned_spectra[[which(ms_levels == 2)[1]]][, "intensity"])
+      df$mz <- list(merged_spec[, "mz"])
+      df$intensity <- list(merged_spec[, "intensity"])
+      
+      k <- k + 1
       #'Convert the modified metadata+peaks into a new 
       #'Spectra object and append it to assembled_list
-      assembled_list[[length(assembled_list) + 1]] <- Spectra(df)
-      next
+      assembled_list[[k]] <- Spectra(df)
     }
     
-    #'If a tree has more than MS2 level
-    #'Combine all cleaned spectra by summing intensities
-    merged_spec <- combine_spectra(cleaned_spectra)
+  
     
-    #'Copy spectraData from the MS2 level 
-    #'of each tree to the new spectra object
-    ms2_row <- idx[ms_levels == 2][1]
-    ms2_meta <- meta[ms2_row, , drop = FALSE]
-    df <- ms2_meta
-    df$spectrum.type <- "assembled"
-    df$MSntreeID <- tree_id
-    #'assign the assembled spectrum to the new spectra object
-    df$mz <- list(merged_spec[, "mz"])
-    df$intensity <- list(merged_spec[, "intensity"])
-    
-    assembled_list[[length(assembled_list) + 1]] <- Spectra(df)
-  }
   
   if (length(assembled_list) == 0) {
     warning("No assembled spectra found!")

--- a/ftms_assembled.qmd
+++ b/ftms_assembled.qmd
@@ -34,16 +34,34 @@ pth <- getwd()
 pth
 ```
 
-First we load the `Spectra` ftms_one_tree object with one representative tree per
-feature.
+First we load the `Spectra` ftms_one_tree object with one representative
+tree per feature.
 
 ```{r}
-load(file.path(pth, "data", "ftms_unique_tree.RData"))
+load(file.path(pth, "data", "ftms_one_tree.RData"))
 class(ftms_one_tree)
 ```
+
+```{r}
+library(Spectra)
+
+# Extract spectraData
+sd <- spectraData(ftms_one_tree)
+
+# Count unique features per MS level
+table(sd$msLevel)  # total spectra per MS level
+
+# Count unique feature IDs per MS level
+unique_features_ms <- tapply(sd$feature_id, sd$msLevel, function(x) length(unique(x)))
+unique_features_ms
+
+```
+
 ## Preprocessing: round mz and remove duplicates
+
 Next we round `mz` values to the first integer using `round_perl()`
-function and keep only the most intense peak if rounding results in duplicated mz.
+function and keep only the most intense peak if rounding results in
+duplicated mz.
 
 ```{r}
 round_perl <- function(number) {
@@ -69,9 +87,11 @@ ftms_one_tree <- addProcessing(ftms_one_tree, peaks_round_mz)
 
 ```
 
-
 ## Combine spectra from the same tree
-Create a function that takes a list of spectra (matrices), sums intensities for identical m/z values across spectra, and returns a merged spectrum.
+
+Create a function that takes a list of spectra (matrices), sums
+intensities for identical m/z values across spectra, and returns a
+merged spectrum.
 
 ```{r}
 #'Combine spectra across a tree
@@ -85,7 +105,6 @@ combine_spectra <- function(spectra_list) {
     as.matrix()
 }
 ```
-
 
 ## Create assembled spectra object
 
@@ -157,74 +176,13 @@ ftms_assembled <- create_assembled_spectra(ftms_one_tree)
 spectraData(ftms_assembled)
 ```
 
-the `spectraData()` contains 511 rows which correspond to the number of
-unique trees in the global object.
-
-example for duplicated peaks in different MS levels of a tree, first we
-print the `spectraData()` and `peaksData()` of the 1813 tree before
-assembling
-
 ```{r}
-#spectraData
-spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$MSntreeID == 1072,]
-
-#peaksData
-idx <- which(spectraData(ftms_one_tree)$MSntreeID == 1072)
-lapply(peaksData(ftms_one_tree)[idx], head) 
+peaksData(ftms_one_tree)[spectraData(ftms_one_tree)$MSntreeID == 1788]
 ```
 
-This tree has 4 MS levels (1 MS2, 2 MS3, 1 MS4). One MS3 peak has the
-same m/z as the MS2 peak.
-
-Now we print the `spectraData()` and `peaksData()` of the 1813 tree
-after assembling
-
 ```{r}
-#spectraData
-spectraData(ftms_assembled)[spectraData(ftms_assembled)$MSntreeID == 1072, ]
-
-#peaksData
-idx <- which(spectraData(ftms_assembled)$MSntreeID == 1072)
-lapply(peaksData(ftms_assembled)[idx], head)
+peaksData(ftms_assembled)[spectraData(ftms_assembled)$MSntreeID == 1788]
 ```
-
-The `spectraData()` of this tree after assembling contains only the MS2
-`spectraData()`, as the other levels were dropped. Moreover, the
-assembled `peaksData()` of this tree contains 4 pairs of (mz, intensity)
-instead of 5 in `ftms_one_tree`, because the m/z of the MS3 level is
-equal to that of the MS4 level; as a result, they were combined into one
-by summing their intensities.
-
-Other example for duplicated peaks in the same MS level of a tree
-
-```{r}
-#spectraData
-spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$MSntreeID == 483,]
-
-#peaksData
-idx <- which(spectraData(ftms_one_tree)$MSntreeID == 483)
-lapply(peaksData(ftms_one_tree)[idx], head) 
-```
-
-This tree has 4 MS levels (1 MS2, 2 MS3, 1 MS4). 2 MS3 peaks has the
-same m/z .
-
-Now we print the `spectraData()` and `peaksData()` of the 483 tree after
-assembling
-
-```{r}
-#spectraData
-spectraData(ftms_assembled)[spectraData(ftms_assembled)$MSntreeID == 483, ]
-
-#peaksData
-idx <- which(spectraData(ftms_assembled)$MSntreeID == 483)
-lapply(peaksData(ftms_assembled)[idx], head)
-```
-
-so the results shows that for the duplicated mz in both MS3 levels of
-this tree, the algorithm keep just one and sum their intensities.
-
-Saving the result to a `RData` object
 
 ```{r}
 save(ftms_assembled, file = file.path(pth, "data", "ftms_assembled.RData"))

--- a/ftms_assembled.qmd
+++ b/ftms_assembled.qmd
@@ -1,0 +1,213 @@
+---
+title: "Create an assembled MS/MS data from Ftms MSn data"
+format:
+  html:
+    toc: true
+    self-contained: true
+author: "Ahlam Mentag, Johannes Rainer"
+editor:
+  markdown:
+    wrap: 72
+---
+
+# Introduction
+
+In this quarto document we create an assembled MS/MS data from ftms
+object that contains one tree per feature created in the
+[ftms_filtering.qmd](https://github.com/rebdau/RDynLib_ftms/blob/ahlam/ftms_filtering.qmd)
+file.
+
+# Data import
+
+Loading all required libraries and importing the results from the ftms
+filtered object.
+
+```{r}
+#| message: false
+library(dplyr)
+library(tidyr)
+library(xcms)
+library(Spectra)
+
+register(SerialParam())
+pth <- getwd()
+pth
+```
+
+First we load the `Spectra` ftms object with one representative tree per
+feature.
+
+```{r}
+load(file.path(pth, "data", "ftms_unique_tree.RData"))
+class(ftms_one_tree)
+```
+
+Next we round `mz` values to the first integer using `round_perl()`
+function
+
+```{r}
+round_perl <- function(number) {
+  floor(number + 0.5)
+}
+
+peaks_round_mz <- function(x, spectrumMsLevel, ...) {
+    x[, 1L] <- round_perl(x[, 1L])
+    x
+}
+
+ftms_one_tree <- addProcessing(ftms_one_tree, peaks_round_mz)
+
+
+```
+
+Merge within same level (keep highest intensity if same mz)
+
+```{r}
+#merge within same level (keep highest intensity if same mz)
+merge_spectra <- function(spectra_list) {
+  do.call(rbind, spectra_list) %>%
+    as.data.frame() %>%
+    group_by(mz) %>%
+    slice_max(order_by = intensity, n = 1, with_ties = FALSE) %>%
+    arrange(mz) %>%
+    as.matrix()
+}
+
+```
+
+Combine across levels (sum intensities if same mz)
+
+```{r}
+#combine across levels (sum intensities if same mz)
+combine_levels <- function(parent, child) {
+  rbind(parent, child) %>%
+    as.data.frame() %>%
+    group_by(mz) %>%
+    summarise(intensity = sum(intensity), .groups = "drop") %>%
+    arrange(mz) %>%
+    as.matrix()
+}
+```
+
+final function to create a new assembled spectra object
+
+```{r}
+
+
+create_assembled_spectra <- function(ftms) {
+  #'Converting the backend to MsBackendMemory 
+  #'so we could modify the peaksData
+  ftms <- setBackend(ftms, MsBackendMemory())
+  meta <- spectraData(ftms)
+  pd_list <- peaksData(ftms)
+  tree_ids <- unique(meta$MSntreeID)
+  
+  assembled_list <- list()
+  
+  for (tree_id in tree_ids) {
+    idx <- which(meta$MSntreeID == tree_id)
+    ms_levels <- meta$msLevel[idx]
+    
+    #'If a tree has only MS2 level, we copy the MS2
+    #'row to the new spectra object as is it.
+    if (max(ms_levels) <= 2L) {
+      ms2_row <- idx[ms_levels == 2][1]
+      ms2_meta <- meta[ms2_row, , drop = FALSE]
+      df <- ms2_meta
+      #'Mark it as assembled
+      df$spectrum.type <- "assembled"
+      df$MSntreeID <- tree_id
+      #copy the same mz and intensity
+      df$mz <- list(pd_list[[ms2_row]][, "mz"])
+      df$intensity <- list(pd_list[[ms2_row]][, "intensity"])
+      #'Convert the modified metadata+peaks into a new 
+      #'Spectra object and append it to assembled_list
+      assembled_list[[length(assembled_list) + 1]] <- Spectra(df)
+      next
+    }
+    
+    #'If a tree has more than MS2 level
+    #'Apply the merge_spectra() function
+    #'to spectra with the same MS level
+    level_list <- split(idx, ms_levels)
+    merged_per_level <- lapply(level_list, function(i) merge_spectra(pd_list[i]))
+    
+    #'Apply the combine_levels() function
+    #'to spectra with different MS levels
+    merged_spec <- Reduce(combine_levels, merged_per_level)
+    
+    #'Copy spectraData from the MS2 level 
+    #'of each tree to the new spectra object
+    ms2_row <- idx[ms_levels == 2][1]
+    ms2_meta <- meta[ms2_row, , drop = FALSE]
+    df <- ms2_meta
+    df$spectrum.type <- "assembled"
+    df$MSntreeID <- tree_id
+    #'assign the assembled spectrum to the new spectra object
+    df$mz <- list(merged_spec[, "mz"])
+    df$intensity <- list(merged_spec[, "intensity"])
+    
+    assembled_list[[length(assembled_list) + 1]] <- Spectra(df)
+  }
+  
+  if (length(assembled_list) == 0) {
+    warning("No assembled spectra found!")
+    return(NULL)
+  }
+  
+  do.call(c, assembled_list)
+}
+
+
+```
+
+Calling the main function
+
+```{r}
+ftms_assembled <- create_assembled_spectra(ftms_one_tree)
+
+spectraData(ftms_assembled)
+```
+
+the `spectraData()` contains 511 rows which correspond to the number of
+unique trees in the global object.
+
+print the `spectraData()` and `peaksData()` of the 1813 tree before
+assembling
+
+```{r}
+#spectraData
+spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$MSntreeID == 1813,]
+
+#peaksData
+idx <- which(spectraData(ftms_one_tree)$MSntreeID == 1813)
+lapply(peaksData(ftms_one_tree)[idx], head) 
+```
+
+This tree has 4 MS levels (1 MS2, 2 MS3, 1 MS4). One MS3 peak has the
+same m/z as the MS4 peak.
+
+Now we print the `spectraData()` and `peaksData()` of the 1813 tree
+after assembling
+
+```{r}
+#spectraData
+spectraData(ftms_assembled)[spectraData(ftms_assembled)$MSntreeID == 1813, ]
+
+#peaksData
+idx <- which(spectraData(ftms_assembled)$MSntreeID == 1813)
+lapply(peaksData(ftms_assembled)[idx], head)
+```
+
+The `spectraData()` of this tree after assembling contains only the MS2
+`spectraData()`, as the other levels were dropped. Moreover, the
+assembled `peaksData()` of this tree contains 4 pairs of (mz, intensity)
+instead of 5 in `ftms_one_tree`, because the m/z of the MS3 level is
+equal to that of the MS4 level; as a result, they were combined into one
+by summing their intensities.
+
+Saving the result to a `RData` object
+
+```{r}
+save(ftms_assembled, file = file.path(pth, "data", "ftms_assembled.RData"))
+```

--- a/ftms_assembled.qmd
+++ b/ftms_assembled.qmd
@@ -60,13 +60,14 @@ ftms_one_tree <- addProcessing(ftms_one_tree, peaks_round_mz)
 
 ```
 
-Merge within same level (keep highest intensity if same mz)
+keep only the most intense peak if the same mz is repeated in the same
+spectrum
 
 ```{r}
-#merge within same level (keep highest intensity if same mz)
-merge_spectra <- function(spectra_list) {
-  do.call(rbind, spectra_list) %>%
-    as.data.frame() %>%
+#'Clean a single spectrum
+#'keep only the most intense peak if the same mz is repeated
+clean_spectrum <- function(spectrum) {
+  as.data.frame(spectrum) %>%
     group_by(mz) %>%
     slice_max(order_by = intensity, n = 1, with_ties = FALSE) %>%
     arrange(mz) %>%
@@ -78,9 +79,10 @@ merge_spectra <- function(spectra_list) {
 Combine across levels (sum intensities if same mz)
 
 ```{r}
-#combine across levels (sum intensities if same mz)
-combine_levels <- function(parent, child) {
-  rbind(parent, child) %>%
+#'Combine spectra across a tree
+#'sum intensities if the same mz appears in different spectra
+combine_spectra <- function(spectra_list) {
+  do.call(rbind, spectra_list) %>%
     as.data.frame() %>%
     group_by(mz) %>%
     summarise(intensity = sum(intensity), .groups = "drop") %>%
@@ -92,7 +94,6 @@ combine_levels <- function(parent, child) {
 final function to create a new assembled spectra object
 
 ```{r}
-
 
 create_assembled_spectra <- function(ftms) {
   #'Converting the backend to MsBackendMemory 
@@ -108,8 +109,12 @@ create_assembled_spectra <- function(ftms) {
     idx <- which(meta$MSntreeID == tree_id)
     ms_levels <- meta$msLevel[idx]
     
+    #'First clean each spectrum individually 
+    #'(remove duplicate mz by keeping the max intensity)
+    cleaned_spectra <- lapply(pd_list[idx], clean_spectrum)
+    
     #'If a tree has only MS2 level, we copy the MS2
-    #'row to the new spectra object as is it.
+    #'row to the new spectra object as is it (after cleaning)
     if (max(ms_levels) <= 2L) {
       ms2_row <- idx[ms_levels == 2][1]
       ms2_meta <- meta[ms2_row, , drop = FALSE]
@@ -117,9 +122,9 @@ create_assembled_spectra <- function(ftms) {
       #'Mark it as assembled
       df$spectrum.type <- "assembled"
       df$MSntreeID <- tree_id
-      #copy the same mz and intensity
-      df$mz <- list(pd_list[[ms2_row]][, "mz"])
-      df$intensity <- list(pd_list[[ms2_row]][, "intensity"])
+      #copy the same mz and intensity (already cleaned)
+      df$mz <- list(cleaned_spectra[[which(ms_levels == 2)[1]]][, "mz"])
+      df$intensity <- list(cleaned_spectra[[which(ms_levels == 2)[1]]][, "intensity"])
       #'Convert the modified metadata+peaks into a new 
       #'Spectra object and append it to assembled_list
       assembled_list[[length(assembled_list) + 1]] <- Spectra(df)
@@ -127,14 +132,8 @@ create_assembled_spectra <- function(ftms) {
     }
     
     #'If a tree has more than MS2 level
-    #'Apply the merge_spectra() function
-    #'to spectra with the same MS level
-    level_list <- split(idx, ms_levels)
-    merged_per_level <- lapply(level_list, function(i) merge_spectra(pd_list[i]))
-    
-    #'Apply the combine_levels() function
-    #'to spectra with different MS levels
-    merged_spec <- Reduce(combine_levels, merged_per_level)
+    #'Combine all cleaned spectra by summing intensities
+    merged_spec <- combine_spectra(cleaned_spectra)
     
     #'Copy spectraData from the MS2 level 
     #'of each tree to the new spectra object
@@ -159,6 +158,7 @@ create_assembled_spectra <- function(ftms) {
 }
 
 
+
 ```
 
 Calling the main function
@@ -172,30 +172,31 @@ spectraData(ftms_assembled)
 the `spectraData()` contains 511 rows which correspond to the number of
 unique trees in the global object.
 
+example for duplicated peaks in different MS levels of a tree, first we
 print the `spectraData()` and `peaksData()` of the 1813 tree before
 assembling
 
 ```{r}
 #spectraData
-spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$MSntreeID == 1813,]
+spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$MSntreeID == 1072,]
 
 #peaksData
-idx <- which(spectraData(ftms_one_tree)$MSntreeID == 1813)
+idx <- which(spectraData(ftms_one_tree)$MSntreeID == 1072)
 lapply(peaksData(ftms_one_tree)[idx], head) 
 ```
 
 This tree has 4 MS levels (1 MS2, 2 MS3, 1 MS4). One MS3 peak has the
-same m/z as the MS4 peak.
+same m/z as the MS2 peak.
 
 Now we print the `spectraData()` and `peaksData()` of the 1813 tree
 after assembling
 
 ```{r}
 #spectraData
-spectraData(ftms_assembled)[spectraData(ftms_assembled)$MSntreeID == 1813, ]
+spectraData(ftms_assembled)[spectraData(ftms_assembled)$MSntreeID == 1072, ]
 
 #peaksData
-idx <- which(spectraData(ftms_assembled)$MSntreeID == 1813)
+idx <- which(spectraData(ftms_assembled)$MSntreeID == 1072)
 lapply(peaksData(ftms_assembled)[idx], head)
 ```
 
@@ -205,6 +206,35 @@ assembled `peaksData()` of this tree contains 4 pairs of (mz, intensity)
 instead of 5 in `ftms_one_tree`, because the m/z of the MS3 level is
 equal to that of the MS4 level; as a result, they were combined into one
 by summing their intensities.
+
+Other example for duplicated peaks in the same MS level of a tree
+
+```{r}
+#spectraData
+spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$MSntreeID == 483,]
+
+#peaksData
+idx <- which(spectraData(ftms_one_tree)$MSntreeID == 483)
+lapply(peaksData(ftms_one_tree)[idx], head) 
+```
+
+This tree has 4 MS levels (1 MS2, 2 MS3, 1 MS4). 2 MS3 peaks has the
+same m/z .
+
+Now we print the `spectraData()` and `peaksData()` of the 483 tree after
+assembling
+
+```{r}
+#spectraData
+spectraData(ftms_assembled)[spectraData(ftms_assembled)$MSntreeID == 483, ]
+
+#peaksData
+idx <- which(spectraData(ftms_assembled)$MSntreeID == 483)
+lapply(peaksData(ftms_assembled)[idx], head)
+```
+
+so the results shows that for the duplicated mz in both MS3 levels of
+this tree, the algorithm keep just one and sum their intensities.
 
 Saving the result to a `RData` object
 

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -375,6 +375,19 @@ Now we save the resulting ftms spectra object to a local directory.
 save(ftms_one_tree, file = file.path(pth, "data", "ftms_unique_tree.RData"))
 ```
 
+
+```{r}
+spectraData(ftms_one_tree)
+```
+
+
+```{r}
+spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$feature_id == "FT0066", ]
+
+```
+
+
+
 # Session information
 
 ```{r}

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -40,9 +40,29 @@ First we load the `XcmsExperiment` ftms object with the preprocessing
 results.
 
 ```{r}
-load(file.path(pth, "data", "ftms_fill_filtergauss.RData"))
+load(file.path(pth, "data", "ftms.RData"))
 class(ftms)
 ```
+
+
+
+```{r}
+ftms
+library(Spectra)
+
+sp <- spectra(ftms)
+
+sp_target <- spectraData(sp)[ spectraData(sp)$scanIndex == 3123 &
+                  spectraData(sp)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S1R4.mzML",] 
+sp_target
+```
+
+```{r}
+peaksData(sp)[spectraData(sp)$scanIndex == 3076 &
+                  spectraData(sp)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S1R2.mzML",][[1,]]
+```
+
+
 
 Next, we use `xcms::featureSpectra()` to extract all MS2 spectra for
 each feature from `ftms` object.
@@ -59,6 +79,36 @@ ms2 <- featureSpectra(dropFilledChromPeaks(ftms), msLevel = 2, skipFilled = TRUE
 msLevel(ms2) |>
   table()
 ```
+
+```{r}
+ms2_S1R4 <- spectraData(ms2)[ spectraData(ms2)$scanIndex == 2742 &
+                  spectraData(ms2)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S9R5.mzML",]
+ms2_S1R4
+```
+
+
+```{r}
+peaksData(ms2)[spectraData(ms2)$scanIndex == 2742 &
+                  spectraData(ms2)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S9R5.mzML",][[1,]]
+
+```
+
+```{r}
+FT5341 <- spectraData(ms2)[ spectraData(ms2)$feature_id == "FT5341",]
+
+FT5341
+```
+
+
+
+```{r}
+ms2_F <- spectraData(ms2)[ spectraData(ms2)$feature_id == "FT4158" &
+                  spectraData(ms2)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S1R4.mzML",]
+ms2_F
+```
+
+
+
 
 ```{r}
 spectraData(ms2)
@@ -372,7 +422,24 @@ have for each feature one representative tree.
 Now we save the resulting ftms spectra object to a local directory.
 
 ```{r}
-save(ftms_one_tree, file = file.path(pth, "data", "ftms_unique_tree.RData"))
+save(ftms_one_tree, file = file.path(pth, "data", "ftms_one_tree.RData"))
+```
+
+```{r}
+load("data/ftms_one_tree.RData")
+```
+
+```{r}
+tst <- spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$feature_id == "FT5291",]
+tst$dataOrigin
+```
+
+```{r}
+peaksData(ftms_one_tree)[spectraData(ftms_one_tree)$feature_id == "FT5291" & spectraData(ftms_one_tree)$msLevel == 2,][[1,]]
+```
+```{r}
+peaksData(ftms_one_tree)[spectraData(ftms_one_tree)$scanIndex == "FT5341" &
+                  spectraData(ftms_one_tree)$msLevel == 2,][[1,]]
 ```
 
 

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -86,10 +86,6 @@ table(msLevel(s))
 In total, there were `r table(msLevel(s))[2]` MS2 spectra. This means that `r round((table(msLevel(s))[2]-length(ms2$feature_id))*100/table(msLevel(s))[2], 1)` % of the MS2
 spectra could not be assigned to any chromatographic peak.
 
-In total, there were 20904 MS2 spectra. This means that 91.10% of the MS2
-spectra ((20904-1860)\*100/20904) could not be assigned to any
-chromatographic peak.
-
 
 The percentage of features with at least one MS2:
 
@@ -353,11 +349,11 @@ unique_tree_feature <- function(db) {
 
 ftms_one_tree <- unique_tree_feature(ftms_msn_tree)
 
-msLevel(ftms_one_tree) |> table()
+print (ta <- msLevel(ftms_one_tree) |> table())
 ```
 
 after selecting one representative tree per feature we have now: MS2 :
-520 and MS3 : 550 and MS4 : 265
+`r ta[1]` and `r ta[2]` and MS4 : `r ta[3]`
 
 Finally we verify if the number of unique features corresponds to the
 number of unique MSntreeID to ensure that we have one tree per feature.

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -14,8 +14,7 @@ editor:
 
 This Quarto document presents the analysis of FTMS flaxseed data for
 selecting one representative tree per feature. Preprocessing and feature
-definition was performed in
-[ftms_preprocessing.qmd](ftms_preprocessing.qmd).
+definition was performed in [Preprocessing steps](ftms_xcms_short.qmd).
 
 # Data import
 
@@ -353,7 +352,7 @@ print (ta <- msLevel(ftms_one_tree) |> table())
 ```
 
 after selecting one representative tree per feature we have now: MS2 :
-`r ta[1]` and `r ta[2]` and MS4 : `r ta[3]`
+`r ta[1]`, MS3 : `r ta[2]`, and MS4 : `r ta[3]`.
 
 Finally we verify if the number of unique features corresponds to the
 number of unique MSntreeID to ensure that we have one tree per feature.

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -45,8 +45,6 @@ load(file.path(pth, "data", "ftms_fill.RData"))
 class(ftms)
 ```
 
-# Explore MS2 spectra associated to features
-
 Next, we use `xcms::featureSpectra()` to extract all MS2 spectra for
 each feature from `ftms` object.
 
@@ -81,8 +79,6 @@ Here we print the initial number of MS levels.
 s <- spectra(ftms)
 table(msLevel(s))
 ```
-
-
 
 In total, there were 20904 MS2 spectra. This means that 91.10% of the MS2
 spectra ((20904-1860)\*100/20904) could not be assigned to any

--- a/ftms_preprocessing.qmd
+++ b/ftms_preprocessing.qmd
@@ -311,7 +311,7 @@ the data should be loaded into memory at a time.
 
 ```{r}
 ftms <- findChromPeaks(
-    ftms, CentWaveParam(peakwidth = c(20, 80), integrate = 2, snthresh = 2,
+    ftms, CentWaveParam(peakwidth = c(20, 80), integrate = 2, snthresh = 6,
                         ppm = 50, prefilter = c(3, 500), mzdiff = 0.001),
     chunkSize = 2)
 ```
@@ -352,6 +352,23 @@ mnpp <- MergeNeighboringPeaksParam(expandRt = 10, expandMz = 0.001,
 ftms <- refineChromPeaks(ftms, mnpp)
 ```
 
+Here we add *CleanPeaksParam* to remove chromatographic peaks with a retention
+time range larger than the provided maximal acceptable width (maxPeakwidth)
+based on (75th percentile of peak widths) * 3.
+
+```{r}
+rt_widths <- unname(pks[, "rtmax"] - pks[, "rtmin"])
+# Compute 75th percentile and multiply by 3
+peakwidth <- quantile(rt_widths, 0.75) * 3
+cpp <- CleanPeaksParam(maxPeakwidth = peakwidth)
+
+ftms <- refineChromPeaks(ftms, cpp)
+```
+
+
+
+
+
 We evaluate the number of peaks and the observed peak widths also after
 refinement.
 
@@ -362,6 +379,104 @@ table(pks[, "sample"])
 quantile(unname(pks[,"rtmax"] - pks[,"rtmin"]))
 quantile(unname(pks[,"mzmax"] - pks[,"mzmin"]))
 ```
+At last we calculate chromatographic peak quality metrics using the
+`chromPeakSummary()` function with the `BetaDistributionParam()`. This resulting
+extra peak shape descriptors, including *beta_cor* can then be used to filter
+low quality peaks. *beta_cor* is the correlation coefficient between the
+extracted ion chromatogram (EIC) peak and an idealized Gaussian peak fitted to
+it. We can use this peak shape descriptor to filter out junk peaks. Here, we
+first look at the distribution of beta_cor:
+
+```{r}
+beta_metrics <- chromPeakSummary(ftms, param = BetaDistributionParam())
+colnames(beta_metrics)
+summary(beta_metrics[, "beta_cor"])
+
+hist(beta_metrics[, "beta_cor"], breaks = 50,
+     main = "Distribution of beta_cor", xlab = "beta_cor")
+```
+
+
+`beta_cor` ranges from -1.0 to 1.0 and has median
+`r median(beta_metrics[, "beta_cor"], na.rm = TRUE)`.
+Most peaks thus have a `beta-cor`close to 1. Negative beta_cor
+values indicate anti-correlation of observed signal with Gaussian-like
+model. These peaks seem to have a valley instead of an apex, maybe multiple
+shoulders or just baseline fluctuation. Peaks with **negative beta_cor must be
+filtered out**. But we could first refine the peaks and evaluate the beta_cor
+values again after refinement before filtering.
+
+```{r}
+#' silently plotting and saving examples for good, intermediate and bad quality
+set.seed(123)
+#' Selecting 12 random peaks with a negative beta_cor
+cid <- rownames(beta_metrics)[which(beta_metrics[, "beta_cor"] < -0.5)] |>
+    sample(size = 12)
+eics <- chromPeakChromatograms(ftms, peaks = cid)
+#' Saving the EICs to a file
+dr <- file.path("images", "chrom_peak_evaluation")
+dir.create(dr, recursive = TRUE, showWarnings = FALSE)
+png(filename = file.path(dr, "chrom_peaks_negative_beta_cor.png"),
+    width = 15, height = 15, units = "cm", res = 600, pointsize = 6)
+plot(eics)
+dev.off()
+
+#' Selecting 12 random peaks with beta_cor around 0
+cid <- rownames(beta_metrics)[which(beta_metrics[, "beta_cor"] > -0.2 &
+                                    beta_metrics[, "beta_cor"] < 0.2)] |>
+    sample(size = 12)
+eics <- chromPeakChromatograms(ftms, peaks = cid)
+#' Saving the EICs to a file
+png(filename = file.path(dr, "chrom_peaks_0_beta_cor.png"),
+    width = 15, height = 15, units = "cm", res = 600, pointsize = 6)
+plot(eics)
+dev.off()
+
+#' Selecting 12 random peaks with beta_cor around 1
+cid <- rownames(beta_metrics)[which(beta_metrics[, "beta_cor"] > 0.9)] |>
+    sample(size = 12)
+eics <- chromPeakChromatograms(ftms, peaks = cid)
+#' Saving the EICs to a file
+png(filename = file.path(dr, "chrom_peaks_1_beta_cor.png"),
+    width = 15, height = 15, units = "cm", res = 600, pointsize = 6)
+plot(eics)
+dev.off()
+
+#' Selecting 12 peaks with a NA beta cor
+cid <- rownames(beta_metrics)[is.na(beta_metrics[, "beta_cor"])] |>
+    sample(size = 12)
+eics <- chromPeakChromatograms(ftms, peaks = cid)
+#' Saving the EICs to a file
+png(filename = file.path(dr, "chrom_peaks_NA_beta_cor.png"),
+    width = 15, height = 15, units = "cm", res = 600, pointsize = 6)
+plot(eics)
+dev.off()
+```
+
+Now we want to filter out junk peaks based on `beta_cor < 0`. This will remove
+`r length(which(beta_metrics[, "beta_cor"] < 0))` peaks with a negative beta
+correlation and `r sum(is.na(beta_metrics[, "beta_cor"]))` peaks with a missing
+beta correlation value of the in total
+`r nrow(beta_metrics)` chromatographic peaks.
+
+```{r}
+#' Keep only chrom peaks with a positive correlation, removing also those
+#' with a missing value.
+ftms <- filterChromPeaks(ftms, keep = which(beta_metrics[, "beta_cor"] > 0))
+```
+
+We evaluate the number of peaks and the observed peak widths.
+
+```{r}
+pks <- chromPeaks(ftms)
+nrow(pks)
+table(pks[, "sample"])
+quantile(unname(pks[,"rtmax"] - pks[,"rtmin"]))
+quantile(unname(pks[,"mzmax"] - pks[,"mzmin"]))
+```
+
+
+
 
 ## Retention time alignment
 
@@ -593,8 +708,21 @@ head(featureValues(ftms))
 
 ```{r}
 #' Save the result object
-save(ftms, file = file.path(pth, "data", "ftms_sh_minfr.RData"))
+save(ftms, file = file.path(pth, "data", "ftms_new_settings.RData"))
 ```
+
+
+```{r}
+tol <- 1e-6
+featureDefinitions(ftms)[
+  !is.na(featureDefinitions(ftms)$mzmed) &
+  featureDefinitions(ftms)$mzmed > 137.023 &
+  featureDefinitions(ftms)$mzmed < 137.025, ]
+
+```
+
+
+
 
 ```{r}
 nrow(featureDefinitions(ftms))

--- a/ftms_preprocessing.qmd
+++ b/ftms_preprocessing.qmd
@@ -52,6 +52,7 @@ with the sample and file information.
 In the following code, *\<my.workdir\>* is the working directory:
 
 ```{r}
+setwd("C:/Users/amentag/Desktop/Rcodes/RDynLib_ftms")
 pth <- getwd()
 pth
 ```
@@ -62,7 +63,7 @@ now we import our dataset
 sample_data_ftms <- read_xlsx(
     file.path(pth, "data/sample_data/ftms_data_files.xlsx")) |>
     as.data.frame()
-MZML_PATH <- file.path(pth,"data","mzML")
+MZML_PATH <- file.path(pth,"data","mzML_cent1")
 ftms <- readMsExperiment(file.path(MZML_PATH, sample_data_ftms$data_file),
                          sampleData = sample_data_ftms)
 ftms
@@ -708,7 +709,7 @@ head(featureValues(ftms))
 
 ```{r}
 #' Save the result object
-save(ftms, file = file.path(pth, "data", "ftms_new_settings.RData"))
+save(ftms, file = file.path(pth, "data", "ftms.RData"))
 ```
 
 
@@ -753,36 +754,8 @@ grid()
 dev.off()
 ```
 
-## Feature matrix
-
-Now we will create the feature matrix of this data.
-
-```{r}
-corrected_features <- featureDefinitions(ftms)
-#here we add a new column called featue in this format "MxTy" with:
-#x: mzmed and y: rtmed of each feature
-
-final_feature_matrix <- data.frame(
- `rt(min)` = corrected_features$rtmed / 60,
-  mzmed = corrected_features$mzmed,
-  feature_name = paste0(
-    "M", round(corrected_features$mzmed, 0),
-    "T", round(corrected_features$rtmed, 0)
-  )
-)
 
 
-```
-
-Now let's print the head of the resulting feature matrix
-
-```{r}
-head(final_feature_matrix)
-```
-
-```{r}
-nrow(final_feature_matrix)
-```
 
 # Session information
 

--- a/ftms_xcms_short.qmd
+++ b/ftms_xcms_short.qmd
@@ -103,28 +103,6 @@ ftms <- findChromPeaks(
     chunkSize = 2)
 ```
 
-
-
-```{r}
-param <- BetaDistributionParam()
-chromPeakSummary(
-  ftms,
-  param,
-  msLevel = 1L,
-  chunkSize = 2L,
-  BPPARAM = bpparam()
-)
-```
-
-
-
-
-
-
-
-
-
-
 > The `xcms::findChromPeaks()` function transforms the
 > `MsExperiment` object (originally created using
 > `MsExperiment::readMsExperiment()` with mzML files and sample
@@ -139,6 +117,7 @@ full data set. The number of peaks per sample are:
 
 ```{r}
 pks <- chromPeaks(ftms)
+nrow(pks)
 table(pks[, "sample"])
 ```
 
@@ -360,7 +339,7 @@ head(featureValues(ftms))
 ```{r}
 #' Save the result object
 
-save(ftms, file = file.path(pth, "data", "ftms_fill.RData"))
+save(ftms, file = file.path(pth, "data", "ftms_fill_filtergauss.RData"))
 
 ```
 

--- a/ftms_xcms_short.qmd
+++ b/ftms_xcms_short.qmd
@@ -103,6 +103,28 @@ ftms <- findChromPeaks(
     chunkSize = 2)
 ```
 
+
+
+```{r}
+param <- BetaDistributionParam()
+chromPeakSummary(
+  ftms,
+  param,
+  msLevel = 1L,
+  chunkSize = 2L,
+  BPPARAM = bpparam()
+)
+```
+
+
+
+
+
+
+
+
+
+
 > The `xcms::findChromPeaks()` function transforms the
 > `MsExperiment` object (originally created using
 > `MsExperiment::readMsExperiment()` with mzML files and sample
@@ -245,6 +267,7 @@ head(featureValues(ftms))
 save(ftms, file = file.path(pth, "data", "ftms_fill.RData"))
 
 ```
+
 
 ```{r}
 nrow(featureDefinitions(ftms))

--- a/ftms_xcms_short.qmd
+++ b/ftms_xcms_short.qmd
@@ -145,7 +145,11 @@ time range larger than the provided maximal acceptable width (maxPeakwidth)
 based on (75th percentile of peak widths) * 3.
 
 ```{r}
-cpp <- CleanPeaksParam(maxPeakwidth = 80)
+rt_widths <- unname(pks[, "rtmax"] - pks[, "rtmin"])
+# Compute 75th percentile and multiply by 3
+peakwidth <- quantile(rt_widths, 0.75) * 3
+cpp <- CleanPeaksParam(maxPeakwidth = peakwidth)
+
 ftms <- refineChromPeaks(ftms, cpp)
 ```
 
@@ -342,6 +346,17 @@ head(featureValues(ftms))
 save(ftms, file = file.path(pth, "data", "ftms_fill_filtergauss.RData"))
 
 ```
+
+
+```{r}
+tol <- 1e-6
+featureDefinitions(ftms)[
+  !is.na(featureDefinitions(ftms)$mzmed) &
+  featureDefinitions(ftms)$mzmed > 137.023 &
+  featureDefinitions(ftms)$mzmed < 137.025, ]
+
+```
+
 
 
 ```{r}


### PR DESCRIPTION
@jorainer, @rebdau, In this PR, I adjusted the centroiding file to apply the peakPeaks() function only on MS1 data. As @rebdau mentioned, the MS2, MS3, and MS4 data were already centroided by the instrument, which is correct because all(centroided(b)) returns True for them. With these new mzML files, I now get the complete peak list.

Even after preprocessing and using featureSpectra(), we still retain all the peaks :). Also, with ftms_one_peak, we observe more peaks.

I think the next step is to decide whether we keep the current conditions (longest tree + precursorIntensity()) or if there’s a better way to select the best FT.

