### PR TITLE
select single best MSn spectral tree: selection workflow improved

### DIFF
--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -266,7 +266,7 @@ assign_msntree_id <- function(x) {
           global_counter <- global_counter + 1
           origin_tree_id[i] <- global_counter
         }
-        ## 🔹 NEW: MS2 spectra have no MS2-level precursor
+        ## MS2 spectra have no MS2-level precursor
         origin_precursor_mz_MS2[i] <- NA_real_
 
       } else {
@@ -278,10 +278,10 @@ assign_msntree_id <- function(x) {
 
           ## assign precursorMz.MS2 depending on depth
           if (level == 3) {
-            ## MS3: parent is MS2 → use parent’s precursorMz
+            ## MS3: parent is MS2; use parent’s precursorMz
             origin_precursor_mz_MS2[i] <- origin_precursor_mz[parent_pos]
           } else if (level == 4) {
-            ## MS4: grandparent is MS2 → fetch its precursorMz
+            ## MS4: grandparent is MS2; fetch its precursorMz
             grandparent_scan <- origin_prec_scan_num[parent_pos]
             grandparent_pos <- scan_idx_map[as.character(grandparent_scan)]
             if (length(grandparent_pos) == 1 && origin_ms_level[grandparent_pos] == 2)
@@ -316,6 +316,8 @@ assign_msntree_id <- function(x) {
   tree_id <- tree_id[order(o)]
   ## reorder new variable to match
   precursor_mz_MS2 <- precursor_mz_MS2[order(o)]
+  
+  x <- x[order(o)]
 
   ## add both to Spectra object
   x$MSntreeID <- tree_id

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -225,7 +225,6 @@ The function `assign_msntree_id()` will:
     -   **`precursorMz.MS2`** — MS2-level precursor m/z propagated to
         MS3/MS4 (and beyond), `NA` for MS2
         
-!!!!!!!!!!!!!TODO: fix function, precursorMz.MS2 is wrong; needs to be == precursorMz if msLevel == 3
 ```{r}
 assign_msntree_id <- function(x) {
   ## Order x by MS level: ensures we first assign an ID to the MS2.
@@ -272,34 +271,24 @@ assign_msntree_id <- function(x) {
       } else {
         ## Assign ID of the related precursor ID
         parent_scan <- origin_prec_scan_num[i]
-        parent_pos <- scan_idx_map[as.character(parent_scan)]
+                parent_pos <- which(origin_scan_index == parent_scan)
         if (length(parent_pos) == 1 && origin_ms_level[parent_pos] == (level - 1)) {
           origin_tree_id[i] <- origin_tree_id[parent_pos]
 
           ## assign precursorMz.MS2 depending on depth
           if (level == 3) {
-            ## MS3: parent is MS2; use parent’s precursorMz
-            origin_precursor_mz_MS2[i] <- origin_precursor_mz[parent_pos]
-          } else if (level == 4) {
-            ## MS4: grandparent is MS2; fetch its precursorMz
-            grandparent_scan <- origin_prec_scan_num[parent_pos]
-            grandparent_pos <- scan_idx_map[as.character(grandparent_scan)]
-            if (length(grandparent_pos) == 1 && origin_ms_level[grandparent_pos] == 2)
-              origin_precursor_mz_MS2[i] <- origin_precursor_mz[grandparent_pos]
-            else
-              origin_precursor_mz_MS2[i] <- NA_real_
+            origin_precursor_mz_MS2[i] <- origin_precursor_mz[i]
           } else {
-            ## Optional: handle MS5+ recursively (rare)
             ancestor_pos <- parent_pos
-            while (ancestor_pos > 0 &&
-                   origin_ms_level[ancestor_pos] > 2) {
-              parent_scan <- origin_prec_scan_num[ancestor_pos]
-              ancestor_pos <- scan_idx_map[as.character(parent_scan)]
+            while (!is.na(ancestor_pos) && origin_ms_level[ancestor_pos] > 3) {
+              ancestor_scan <- origin_prec_scan_num[ancestor_pos]
+              ancestor_pos <- scan_idx_map[as.character(ancestor_scan)]
             }
-            if (!is.na(ancestor_pos) && origin_ms_level[ancestor_pos] == 2)
+            if (!is.na(ancestor_pos) && origin_ms_level[ancestor_pos] == 3) {
               origin_precursor_mz_MS2[i] <- origin_precursor_mz[ancestor_pos]
-            else
+            } else {
               origin_precursor_mz_MS2[i] <- NA_real_
+            }
           }
 
         } else {

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -225,7 +225,7 @@ The function `assign_msntree_id()` will:
     -   **`precursorMz.MS2`** — MS2-level precursor m/z propagated to
         MS3/MS4 (and beyond), `NA` for MS2
         
-
+!!!!!!!!!!!!!TODO: fix function, precursorMz.MS2 is wrong; needs to be == precursorMz if msLevel == 3
 ```{r}
 assign_msntree_id <- function(x) {
   ## Order x by MS level: ensures we first assign an ID to the MS2.
@@ -465,17 +465,217 @@ This looks like a really good selection !
 
 # Add additional MS3 and MS4 spectra, with different precursorMz, to the selected trees
 
-Here, the purpose is to add, from the "strong" spectral trees with MS2
-precursor intensity in top 75 %, MS3 spectra with different MS2 precursorMz, and MS4 spectra with different MS3 or MS4 precursorMz, to the selected
-`ftms_msn_tree_best`.
-Create new integer variable to group spectra from different authentic MSn trees into merged MSn trees: `ftms_msn_tree_best$MergedMSntreeID`
+Here, the purpose is to enrich the selected “best” MSn trees (`ftms_msn_tree_best`) with additional MS3-MS4 spectra from other MS2 and/or MS3 precursors belonging to the same feature, to build a more complete merged fragmentation tree.
+Add, from the "strong" spectral trees with MS2 precursor intensity in top 75 %, MS3 spectra with different MS2 precursorMz, and MS4 spectra with different MS3 or MS4 precursorMz, to the selected `ftms_msn_tree_best`.
+Create new integer variable: `ftms_msn_tree_best$MergedMSntreeID`.
+All spectra belonging to the same merged tree (`ftms_msn_tree_best` + added MS3-MS4) will share the same `MergedMSntreeID`.
+Each feature will have 1 merged tree ID.
 
 ## MS3-MS4 spectra from other MS2 precursor
-Add to MSntrees of features in `ftms_msn_tree_best`, MS3 spectra, from the 75% "strong" trees `sd_filtered`, belonging to same feature but having different `round(precurosrMz)` :
+Add within each MSntree of `ftms_msn_tree_best`, MS3 spectra, from the 75% "strong" trees `sd_filtered`, belonging to same feature but having different `round(precurosrMz)` :
 Select longest tree (meaning MS3 with depending MS4 in the same MSntree_id)
 from these, select highest total peakCounts
 if ties, select highest precursor Intensity of MS3 spectrum
 
+```{r}
+#####CODE ALMOST WORKS!!!!!!!!!!!!!!!!!!!!!
+# Extract spectraData from ftms_msn_tree_best
+sd_best <- as.data.frame(spectraData(ftms_msn_tree_best))
+
+sd_filtered$precMzRound <- round(sd_filtered$precursorMz)
+sd_best$precMzRound <- round(sd_best$precursorMz)
+
+# Extract MS4 spectra from sd_filtered
+# ms3_acq: acquisition number of the parent MS3 spectrum
+# ms4_acq: acquisition number of the MS4 spectrum
+# peaksCount.MS4: peaksCOunt of MS4 spectrum
+ms4_spectra <- sd_filtered %>%
+  filter(msLevel == 4) %>%
+  select(MSntreeID, precScanNum, acquisitionNum, peaksCount) %>%
+  dplyr::rename(ms3_acq = precScanNum, ms4_acq = acquisitionNum, peaksCount.MS4 = peaksCount)
+
+#testfunctie3 works! : it selects the candidate MS3 with highest depth -> most total peaks -> highest precursorIntensity
+   testfunctie3 <- function(x) {
+  x %>%
+    {
+      if (any(!is.na(.$ms4_acq))) {
+        dplyr::filter(., !is.na(ms4_acq))
+        
+      } else {
+        .
+      }
+    }%>%
+    dplyr::mutate(pc = rowSums(cbind(peaksCount, peaksCount.MS4), na.rm = TRUE)) %>%
+     # sort descending by pc, then precursorIntensity
+    arrange(desc(pc), desc(precursorIntensity)) %>%
+    # keep only the top row
+    slice_head(n = 1)
+   }
+  
+   # testfunctie4: appends also, to the selected additional MS3, the depending MS4 if any
+  testfunctie4 <- function(x) {
+  # Filter MS4 if any exist, compute pc, sort, keep top MS3
+  top_ms3 <- x %>%
+    {
+      if (any(!is.na(.$ms4_acq))) {
+        dplyr::filter(., !is.na(ms4_acq))
+      } else {
+        .
+      }
+    } %>%
+    dplyr::mutate(pc = rowSums(cbind(peaksCount, peaksCount.MS4), na.rm = TRUE)) %>%
+    dplyr::arrange(desc(pc), desc(precursorIntensity)) %>%
+    dplyr::slice_head(n = 1)
+
+  # Add corresponding MS4 spectra, if ms4_acq exists
+  if (!all(is.na(top_ms3$ms4_acq))) {
+    ms4_row <- sd_filtered %>%
+  filter(msLevel == 4, acquisitionNum %in% top_ms3$ms4_acq, feature_id == top_ms3$feature_id)
+combined <- bind_rows(top_ms3, ms4_row)
+    
+    
+  } else {
+    combined <- top_ms3
+  }
+
+  combined
+} 
+# Initialize empty list to store additional MS3
+all_additional_ms3 <- list()
+
+for (f in unique(sd_best$feature_id)) {
+  
+  # Best MSn tree for this feature
+  best_tree <- sd_best %>% filter(feature_id == f)
+  best_precMz <- unique(best_tree$precMzRound[best_tree$msLevel == 3])
+  
+  # Candidate MS3 spectra with different precursor m/z
+  ms3_candidates <- sd_filtered %>%
+    filter(feature_id == f,
+           msLevel == 3,
+           !(round(precursorMz) %in% best_precMz))
+  
+  # Only continue if there are candidates
+  if (nrow(ms3_candidates) != 0) {
+    print(paste(f,"has", nrow(ms3_candidates), "additional MS3 candidates.", sep=" " ))
+
+    # Join MS3 candidates to their dependent MS4 (if exists)
+    ms3_candidates <- ms3_candidates %>%
+      left_join(ms4_spectra, by = c("MSntreeID" = "MSntreeID", "acquisitionNum" = "ms3_acq"))
+    
+  
+    # Group by precMzRound and select best MS3
+
+    ms3.p.precmz <- split(ms3_candidates, ms3_candidates$precMzRound)
+    additional.ms3 <- lapply(ms3.p.precmz, testfunctie4)
+    all_additional_ms3[[f]] <- do.call(rbind, additional.ms3)
+  }
+}
+
+# Bind all features into a single data frame
+all_additional_ms3 <- do.call(rbind, all_additional_ms3)
+row.names(all_additional_ms3) <- NULL
+
+
+
+# merge the additional MS3 spectra to the selected best trees
+common_cols <- intersect(names(sd_best), names(all_additional_ms3))
+merged <- bind_rows(
+  sd_best[, common_cols],
+  all_additional_ms3[, common_cols]
+)  
+
+# create new unique merged tree ID 
+merged <- merged %>%
+  mutate(MergedMSntreeID = as.integer(factor(feature_id)))
+
+
+mergeKey <- paste(merged$dataOrigin, merged$scanIndex, sep = "_")
+
+original_key <- paste(spectraData(ftms_msn_tree)$dataOrigin,
+                      spectraData(ftms_msn_tree)$scanIndex,
+                      sep = "_")
+
+merged_spectra <- ftms_msn_tree[original_key %in% mergeKey]
+merged <- S4Vectors::DataFrame(merged)
+spectraData(merged_spectra) <- merged
+
+
+```
+TODO: solve BUG:
+some lines are duplicated:from MSntreeID 1559, MS4 with precMzRound 545, is appended again
+> merged[merged$feature_id=="FT4198",]
+DataFrame with 8 rows and 46 columns
+    msLevel     rtime acquisitionNum scanIndex    dataStorage     dataOrigin centroided  smoothed  polarity
+  <integer> <numeric>      <integer> <integer>    <character>    <character>  <logical> <logical> <integer>
+1         2   2066.95           3568      3568 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
+2         3   2064.87           3569      3569 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
+3         3   2065.19           3570      3570 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
+4         4   2065.51           3571      3571 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
+5         4   2064.52           3571      3571 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
+6         4   2065.51           3571      3571 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
+7         3   2062.21           3566      3566 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
+8         3   2067.24           3507      3507 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
+  precScanNum precursorMz precursorIntensity precursorCharge collisionEnergy isolationWindowLowerMz
+    <integer>   <numeric>          <numeric>       <integer>       <numeric>              <numeric>
+1        3567     677.134         126397.703               2              35                     NA
+2        3568     707.100            883.993               0              35                     NA
+3        3568     647.160            807.771               0              35                     NA
+4        3569     545.130            321.628               0              35                     NA
+5        3569     484.480            116.030               0              35                     NA
+6        3569     545.130            321.628               0              35                     NA
+7        3565     596.070            553.066               0              35                     NA
+8        3506     729.090            535.596               0              35                     NA
+  isolationWindowTargetMz isolationWindowUpperMz peaksCount totIonCurrent basePeakMZ basePeakIntensity
+                <numeric>              <numeric>  <integer>     <numeric>  <numeric>         <numeric>
+1                      NA                     NA         33    5758.27579    707.095         883.99316
+2                      NA                     NA          6     475.90352    545.132         321.62772
+3                      NA                     NA          4     463.92892    484.929         314.61465
+4                      NA                     NA          3      73.31370    445.117          33.29948
+5                      NA                     NA          1       8.67285    301.050           8.67285
+6                      NA                     NA          3      73.31370    445.117          33.29948
+7                      NA                     NA         11     489.00798    485.227          95.01157
+8                      NA                     NA          4     124.09554    629.146          62.68373
+  ionisationEnergy     lowMZ    highMZ mergedScan mergedResultScanNum mergedResultStartScanNum
+         <numeric> <numeric> <numeric>  <integer>           <integer>                <integer>
+1                0   295.291  1015.097         NA                  NA                       NA
+2                0   299.205   563.556         NA                  NA                       NA
+3                0   305.069   484.929         NA                  NA                       NA
+4                0   254.943   445.117         NA                  NA                       NA
+5                0   301.050   301.050         NA                  NA                       NA
+6                0   254.943   445.117         NA                  NA                       NA
+7                0   216.861   869.306         NA                  NA                       NA
+8                0   427.205   711.211         NA                  NA                       NA
+  mergedResultEndScanNum injectionTime filterString    spectrumId ionMobilityDriftTime scanWindowLowerLimit
+               <integer>     <numeric>  <character>   <character>            <numeric>            <numeric>
+1                     NA             0           NA controller...                   NA              295.291
+2                     NA             0           NA controller...                   NA              299.205
+3                     NA             0           NA controller...                   NA              305.069
+4                     NA             0           NA controller...                   NA              254.943
+5                     NA             0           NA controller...                   NA              301.050
+6                     NA             0           NA controller...                   NA              254.943
+7                     NA             0           NA controller...                   NA              216.861
+8                     NA             0           NA controller...                   NA              427.205
+  scanWindowUpperLimit electronBeamEnergy chrom_peak_rt chrom_peak_mz chrom_peak_id feature_rtmed
+             <numeric>          <numeric>     <numeric>     <numeric>   <character>     <numeric>
+1             1015.097                 NA       2070.51       677.134       CP57620       2070.93
+2              563.556                 NA            NA            NA            NA            NA
+3              484.929                 NA            NA            NA            NA            NA
+4              445.117                 NA            NA            NA            NA            NA
+5              301.050                 NA            NA            NA            NA            NA
+6              445.117                 NA            NA            NA            NA            NA
+7              869.306                 NA            NA            NA            NA            NA
+8              711.211                 NA            NA            NA            NA            NA
+  feature_mzmed  feature_id rtime_adjusted MSntreeID precursorMz.MS2 precMzRound MergedMSntreeID
+      <numeric> <character>      <numeric> <numeric>       <numeric>   <numeric>       <integer>
+1       677.133      FT4198             NA      1559              NA         677             298
+2            NA      FT4198        2067.22      1559         677.134         707             298
+3            NA      FT4198        2067.54      1559         677.134         647             298
+4            NA      FT4198        2067.86      1559         677.134         545             298
+5            NA      FT4198        2068.19      1390         677.132         484             298
+6            NA      FT4198        2067.86      1559         677.134         545             298
+7            NA      FT4198        2065.87      1389         677.132         596             298
+8            NA      FT4198        2067.51      1189         677.130         729             298
 ## MS4 spectra from other `round(`precursor_mz_MS2)` 
 
 ## MS4 spectra from same `round(`precursor_mz_MS2)`, but different `round(precursorMz)`.

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -466,10 +466,20 @@ This looks like a really good selection !
 # Add additional MS3 and MS4 spectra, with different precursorMz, to the selected trees
 
 Here, the purpose is to add, from the "strong" spectral trees with MS2
-precursorMz in top 75 %, MS3 spectra with different MS2 precursorMz, and
-MS4 spectra with different MS3 or MS4 precursorMz, to the selected
-`ftms_msn_tree_best`. I would select again based on peakCOunts and, if
-ties, precursorIntensity.
+precursor intensity in top 75 %, MS3 spectra with different MS2 precursorMz, and MS4 spectra with different MS3 or MS4 precursorMz, to the selected
+`ftms_msn_tree_best`.
+Create new integer variable to group spectra from different authentic MSn trees into merged MSn trees: `ftms_msn_tree_best$MergedMSntreeID`
+
+## MS3-MS4 spectra from other MS2 precursor
+Add to MSntrees of features in `ftms_msn_tree_best`, MS3 spectra, from the 75% "strong" trees `sd_filtered`, belonging to same feature but having different `round(precurosrMz)` :
+Select longest tree (meaning MS3 with depending MS4 in the same MSntree_id)
+from these, select highest total peakCounts
+if ties, select highest precursor Intensity of MS3 spectrum
+
+## MS4 spectra from other `round(`precursor_mz_MS2)` 
+
+## MS4 spectra from same `round(`precursor_mz_MS2)`, but different `round(precursorMz)`.
+
 
 after selecting one representative tree per feature we have now: MS2 :
 `r ta[1]`, MS3 : `r ta[2]`, and MS4 : `r ta[3]`.

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -587,6 +587,130 @@ spectraData(merged_spectra) <- merged
 
 ## MS4 spectra from other `round(`precursor_mz_MS2)` 
 
+Identify “new” MS4 spectra in sd_filtered that aren’t already in merged trees, but are connected to existing MS3 spectra via matching precursor m/z values, and also have precursor m/z matching actual fragment peaks of those MS3 spectra.
+
+###Create set of candidate new MS4 spectra
+```{r}
+# Prepare subsets of the merged spectra
+merged_sd <- as.data.frame(spectraData(merged_spectra))
+
+ms3_merged <- merged_sd %>% filter(msLevel == 3)
+ms4_merged <- merged_sd %>% filter(msLevel == 4)
+
+# Select candidate MS4 spectra from sd_filtered :
+# their MS3 parent spectrum exists in merged_spectra (to verify based on presence of their precursorMz.MS2 in ms3_merged$precursorMz)
+# precursorMz.MS2 is not already present among MS4 spectra of merged_spectra
+ms4_candidates <- sd_filtered %>%
+  filter(
+    msLevel == 4,
+    !(precursorMz.MS2 %in% ms4_merged$precursorMz.MS2),
+    precursorMz.MS2 %in% ms3_merged$precursorMz
+  )
+```
+
+### Retain only cadidate MS4 spectra for which the precursor m/z (precursorMz) is present among the peaks of its corresponding MS3 parent spectrum in the merged_spectra object.
+```{r}
+# Identify MS3 spectra in best or merged trees, that could be parents of the candidate new MS4 spectra
+parent_ms3_precursors <- unique(ms4_candidates$precursorMz.MS2)
+ms3_parents_sd <- ms3_merged %>%
+  filter(precursorMz %in% parent_ms3_precursors)
+ms3_parents <- paste(ms3_parents_sd$dataOrigin,ms3_parents_sd$scanIndex)
+
+# Extract peaksData from merged_spectra only for relevant MS3 spectra
+pd <- peaksData(merged_spectra)
+sd <- spectraData(merged_spectra)
+
+spectra_id <- paste(sd$dataOrigin,sd$scanIndex)
+
+ms3_indices <- which(spectra_id %in% ms3_parents)
+peaks.ms3parents.list <- as.list(pd[ms3_indices,])
+
+### filter  ms4_candidates so that each candidate MS4 spectrum is retained only if its precursor m/z (precursorMz) is present among the peaks of its corresponding MS3 parent spectrum.
+
+# Build lookup of rounded parent precursorMz → rounded peaks
+parent_lookup <- lapply(peaks.ms3parents.list, function(x) round(x[, 1]))
+names(parent_lookup) <- as.character(round(ms3_parents_sd$precursorMz))
+
+# Round MS4 precursor columns for matching
+ms4_candidates <- ms4_candidates %>%
+  mutate(
+    precursorMz_round = round(precursorMz),
+    precursorMz_MS2_round = round(precursorMz.MS2)
+  )
+
+# For each candidate, check if its rounded precursor is in the parent’s rounded peaks
+keep_idx <- logical(nrow(ms4_candidates))
+
+for (i in seq_len(nrow(ms4_candidates))) {
+  parent_key <- as.character(ms4_candidates$precursorMz_MS2_round[i])
+  if (parent_key %in% names(parent_lookup)) {
+    keep_idx[i] <- ms4_candidates$precursorMz_round[i] %in% parent_lookup[[parent_key]]
+  } else {
+    keep_idx[i] <- FALSE
+  }
+}
+
+# Filter retained candidates
+ms4_candidates_filtered <- ms4_candidates[keep_idx, ]
+```
+
+### Select MS4 candidate spectrum with highest number of peaks
+```{r}
+# Create composite key precMS2.precMS3
+ms4_candidates_filtered <- ms4_candidates_filtered %>%
+  mutate(
+    precMS2.precMS3 = paste0(
+      "precMS2_", round(precursorMz.MS2),
+      "_precMS3_", round(precursorMz)
+    )
+  )
+
+# Keep only MS4 spectrum with the highest number of peaks per unique precMS2.precMS3
+newms4_best <- ms4_candidates_filtered %>%
+  group_by(precMS2.precMS3) %>%
+  slice_max(order_by = peaksCount, n = 1, with_ties = FALSE) %>%
+  ungroup()
+```
+
+### Append new MS4 spectra (newms4_best) to merged MSntree dataset
+```{r}
+# Prepare metadata for merging
+sd_merged <- as.data.frame(spectraData(merged_spectra))
+
+# Round precursor m/z for matching consistency
+sd_merged$precMzRound <- round(sd_merged$precursorMz)
+newms4_best$precMzRound <- round(newms4_best$precursorMz)
+
+# Create merge keys (for later extraction from original dataset)
+mergeKey_existing <- paste(sd_merged$dataOrigin, sd_merged$scanIndex, sep = "_")
+mergeKey_newms4   <- paste(newms4_best$dataOrigin, newms4_best$scanIndex, sep = "_")
+
+# Combine metadata tables
+common_cols <- intersect(names(sd_merged), names(newms4_best))
+
+merged_df <- bind_rows(
+  sd_merged[, common_cols],
+  newms4_best[, common_cols]
+)
+
+# Assign new merged tree IDs
+merged_df <- merged_df %>%
+  mutate(MergedMSntreeID = as.integer(factor(feature_id)))
+
+# Update Spectra object
+# Locate spectra in original Spectra object
+original_sd <- as.data.frame(spectraData(ftms_msn_tree))  
+original_key <- paste(original_sd$dataOrigin, original_sd$scanIndex, sep = "_")
+
+# Subset original spectra that match the merged table
+merged_spectra <- ftms_msn_tree[original_key %in% c(mergeKey_existing, mergeKey_newms4)]
+
+# Replace spectraData with updated merged table
+spectraData(merged_spectra) <- S4Vectors::DataFrame(merged_df)
+
+```
+
+
 ## MS4 spectra from same `round(`precursor_mz_MS2)`, but different `round(precursorMz)`.
 
 

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -52,17 +52,8 @@ library(Spectra)
 
 sp <- spectra(ftms)
 
-sp_target <- spectraData(sp)[ spectraData(sp)$scanIndex == 3123 &
-                  spectraData(sp)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S1R4.mzML",] 
-sp_target
 ```
-
-```{r}
-peaksData(sp)[spectraData(sp)$scanIndex == 3076 &
-                  spectraData(sp)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S1R2.mzML",][[1,]]
-```
-
-
+# Associate MS2 spectra to features
 
 Next, we use `xcms::featureSpectra()` to extract all MS2 spectra for
 each feature from `ftms` object.
@@ -80,39 +71,8 @@ msLevel(ms2) |>
   table()
 ```
 
-```{r}
-ms2_S1R4 <- spectraData(ms2)[ spectraData(ms2)$scanIndex == 2742 &
-                  spectraData(ms2)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S9R5.mzML",]
-ms2_S1R4
-```
 
 
-```{r}
-peaksData(ms2)[spectraData(ms2)$scanIndex == 2742 &
-                  spectraData(ms2)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S9R5.mzML",][[1,]]
-
-```
-
-```{r}
-FT5341 <- spectraData(ms2)[ spectraData(ms2)$feature_id == "FT5341",]
-
-FT5341
-```
-
-
-
-```{r}
-ms2_F <- spectraData(ms2)[ spectraData(ms2)$feature_id == "FT4158" &
-                  spectraData(ms2)$dataOrigin == "C:\\Users\\amentag\\Desktop\\Rcodes\\RDynLib_ftms\\data\\mzML_cent1\\S1R4.mzML",]
-ms2_F
-```
-
-
-
-
-```{r}
-spectraData(ms2)
-```
 
 it returns `r length(ms2)` MS level 2 spectra. The total number of features for
 which an MS2 spectrum was identified is:
@@ -197,6 +157,7 @@ ms2_mult <- names(ms2_table)[ms2_table > 1]
 
 Of the `r length(unique(ms2_id))` MS2 spectra, `r length(ms2_mult)` are assigned
 to more than one feature. 
+
 
 # Extract all MS2-MSn spectra associated to features
 
@@ -363,43 +324,86 @@ The number of trees that go up to MS2 level is : `r t[1]`. The number of
 trees that go up to MS3 level is : `r t[2]`. The number of trees that go up to
 MS4 level is : `r t[3]`.
 
-Next we select one most representative tree per feature based on the
-longest one and if we have many, we select one tree with the highest MS2
-precursor intensity
+# Select single best MSn spectral tree per feature
+
+
+Next we select one most representative tree per feature based on (1) the intensity of the precursor, (2) the length of the tree, (3) the total number of peaks in all spectra of the tree, and (4) in rare cases of several trees with maximal number of peaks: break ties based on precursor intensity (max)
+
+## (1) Filter out weak precursor trees (lowest precursor intensity)
+Keep only trees (`vMSntreeID`v) whose `msLevel == 2` spectrum precursor intensity is in the top 75%.
 
 ```{r}
-
-unique_tree_feature <- function(db) {
-  # Store MS2 indices
-  ms2_idx <- which(msLevel(db) == 2)
-
-  # Table of linked MS2 features only
-  feat_ms2 <- data.frame(
-    idx = ms2_idx,
-    feature_id = sapply(db$feature_id[ms2_idx], function(x) x[1]),
-    MSntreeID = db$MSntreeID[ms2_idx],
-    precursorIntensity = db$precursorIntensity[ms2_idx]
-  )
-
-  # for each feature choose the longest tree and the one with the highest
-  #precursorIntensity()  in case of tie
-  selected_tree_ids <- tapply(seq_len(nrow(feat_ms2)), feat_ms2$feature_id, function(i) {
-    #the longest tree
-    tbl <- table(feat_ms2$MSntreeID[i])
-    FTmax <- as.numeric(names(tbl)[tbl == max(tbl)])
-    #the highest precursorIntensity()
-    sub_idx <- i[feat_ms2$MSntreeID[i] %in% FTmax]
-    sub_idx[which.max(feat_ms2$precursorIntensity[sub_idx])]
-  })
-
-  tree_ids_keep <- feat_ms2$MSntreeID[unlist(selected_tree_ids)]
-  db[which(db$MSntreeID %in% tree_ids_keep)]
-}
-
-ftms_one_tree <- unique_tree_feature(ftms_msn_tree)
-
-print (ta <- msLevel(ftms_one_tree) |> table())
+sd <- as.data.frame(spectraData(ftms_msn_tree))
+ms2 <- subset(sd, msLevel == 2)
+threshold <- quantile(ms2$precursorIntensity, 0.25, na.rm = TRUE)
+strong_MSntrees <- unique(ms2$MSntreeID[ms2$precursorIntensity > threshold])
+sd_filtered <- subset(sd, MSntreeID %in% strong_MSntrees)
 ```
+
+
+## (2) Among 75% remaining MSn trees, select the longest tree per feature
+```{r}
+# Get max msLevel per tree
+tree_length <- aggregate(msLevel ~ MSntreeID + feature_id, data = sd_filtered, max)
+
+# Get max depth per feature
+max_len <- aggregate(msLevel ~ feature_id, data = tree_length, max)
+
+# Keep only trees with the maximum length for their feature
+longest_trees <- merge(tree_length, max_len, by = c("feature_id", "msLevel"))
+
+```
+
+
+## (3) select the tree with highest total number of peaks in all levels
+total number of peaks: sum of peaksCount per tree_id in spectraData
+
+```{r}
+tree_peaks <- aggregate(peaksCount ~ MSntreeID, data = sd_filtered, sum)
+
+candidate_trees <- merge(longest_trees, tree_peaks, by = "MSntreeID")
+max_peaks <- aggregate(peaksCount ~ feature_id, data = candidate_trees, max)
+candidate_trees <- merge(candidate_trees, max_peaks, by.x = c("feature_id", "peaksCount"), by.y = c("feature_id", "peaksCount"))
+
+```
+
+## (4) break ties by precursor intensity (highest)
+```{r}
+# Compute maximal precursor intensity of MS2 spectra per tree
+prec_max <- aggregate(precursorIntensity ~ MSntreeID, data = ms2, max)
+candidate_trees <- merge(candidate_trees, prec_max, by = "MSntreeID")
+
+# select the tree with highest precursor intensity per feature
+candidate_trees <- candidate_trees[order(candidate_trees$feature_id, -candidate_trees$precursorIntensity), ]
+best_tree <- candidate_trees[!duplicated(candidate_trees$feature_id), c("feature_id", "MSntreeID")]
+```
+
+## (5) filter Spectra object
+```{r}
+best_MSntreeIDs <- best_tree$MSntreeID
+ftms_msn_tree_best <- ftms_msn_tree[ which(spectraData(ftms_msn_tree)$MSntreeID %in% best_MSntreeIDs) ]
+```
+
+## (6) (Optional) evaluate based on known spectra
+```{r}
+idx <- which(round(ftms_msn_tree_best$precursorMz) == 1333)
+idx
+peaksData(ftms_msn_tree_best)[idx][[1]]
+
+
+idx <- which(round(ftms_msn_tree_best$precursorMz) == 1171)
+idx
+peaksData(ftms_msn_tree_best)[idx][[1]]
+peaksData(ftms_msn_tree_best)[idx][[2]]
+```
+This looks like a really good selection !
+
+# Add additional MS3 and MS4 spectra, with different precursorMz, to the selected trees
+
+Here, the purpose is to add, from the "strong" spectral trees with MS2 precursorMz in top 75 %, MS3 spectra with different MS2 precursorMz, and MS4 spectra with different MS3 or MS4 precursorMz, to the selected `ftms_msn_tree_best`. I would select again based on peakCOunts and, if ties, precursorIntensity.
+
+
+
 
 after selecting one representative tree per feature we have now: MS2 :
 `r ta[1]`, MS3 : `r ta[2]`, and MS4 : `r ta[3]`.

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -206,25 +206,30 @@ table(msLevel(ftms_msn_tree))
 
 # Grouping MSn spectra into fragmentation trees
 
-We now group all spectra that belong to the same fragmentation tree and record the precursor m/z of the originating MS2 spectrum for each spectrum within that tree.
-
+We now group all spectra that belong to the same fragmentation tree and
+record the precursor m/z of the originating MS2 spectrum for each
+spectrum within that tree.
 
 The function `assign_msntree_id()` will:
 
 -   Take a `Spectra` object `x` containing MS2–MSn spectra\
+
 -   Assign tree IDs to each spectrum in `x`, based on precursor
     relationships within each sample (`dataOrigin`)\
+
 -   Ensure that MS2 spectra always start a new tree, and that MS3/MS4
     spectra inherit the tree ID from their parent\
+
 -   Propagate the MS2-level precursor m/z to all downstream spectra in
     the same tree (MS3, MS4, …), with `NA` for MS2 spectra\
+
 -   Return the updated `Spectra` object with two new spectra variables:
 
     -   **`MSntreeID`** — integer ID of the fragmentation tree each
         spectrum belongs to\
     -   **`precursorMz.MS2`** — MS2-level precursor m/z propagated to
         MS3/MS4 (and beyond), `NA` for MS2
-        
+
 ```{r}
 assign_msntree_id <- function(x) {
   ## Order x by MS level: ensures we first assign an ID to the MS2.
@@ -454,20 +459,29 @@ This looks like a really good selection !
 
 # Add additional MS3 and MS4 spectra, with different precursorMz, to the selected trees
 
-Here, the purpose is to enrich the selected “best” MSn trees (`ftms_msn_tree_best`) with additional MS3-MS4 spectra from other MS2 and/or MS3 precursors belonging to the same feature, to build a more complete merged fragmentation tree.
-Add, from the "strong" spectral trees with MS2 precursor intensity in top 75 %, MS3 spectra with different MS2 precursorMz, and MS4 spectra with different MS3 or MS4 precursorMz, to the selected `ftms_msn_tree_best`.
-Create new integer variable: `ftms_msn_tree_best$MergedMSntreeID`.
-All spectra belonging to the same merged tree (`ftms_msn_tree_best` + added MS3-MS4) will share the same `MergedMSntreeID`.
-Each feature will have 1 merged tree ID.
+Here, the purpose is to enrich the selected “best” MSn trees
+(`ftms_msn_tree_best`) with additional MS3-MS4 spectra from other MS2
+and/or MS3 precursors belonging to the same feature, to build a more
+complete merged fragmentation tree. Add, from the "strong" spectral
+trees with MS2 precursor intensity in top 75 %, MS3 spectra with
+different MS2 precursorMz, and MS4 spectra with different MS3 or MS4
+precursorMz, to the selected `ftms_msn_tree_best`. Create new integer
+variable: `ftms_msn_tree_best$MergedMSntreeID`. All spectra belonging to
+the same merged tree (`ftms_msn_tree_best` + added MS3-MS4) will share
+the same `MergedMSntreeID`. Each feature will have 1 merged tree ID.
 
 ## MS3-MS4 spectra from other MS2 precursor
-Add within each MSntree of `ftms_msn_tree_best`, MS3 spectra, from the 75% "strong" trees `sd_filtered`, belonging to same feature but having different `round(precurosrMz)` :
-Select longest tree (meaning MS3 with depending MS4 in the same MSntree_id)
-from these, select highest total peakCounts
-if ties, select highest precursor Intensity of MS3 spectrum
+
+Add within each MSntree of `ftms_msn_tree_best`, MS3 spectra, from the
+75% "strong" trees `sd_filtered`, belonging to same feature but having
+different `round(precurosrMz)` : Select longest tree (meaning MS3 with
+depending MS4 in the same MSntree_id) from these, select highest total
+peakCounts if ties, select highest precursor Intensity of MS3 spectrum
 
 ### Create selectbest.ms3ms4() function:
-This function selects best MS3 spectra to be added to merged MSntree, and appends any dependent MS4 spectra from the same feature
+
+This function selects best MS3 spectra to be added to merged MSntree,
+and appends any dependent MS4 spectra from the same feature
 
 ```{r}
 # Input: a dataframe with spectraData of all MS3 spectra to be added to the MSntree of a specific feature.
@@ -506,6 +520,7 @@ combined <- bind_rows(top_ms3, ms4_row)
 ```
 
 ### Prepare merged MSntree dataset
+
 ```{r}
 # Extract spectraData from ftms_msn_tree_best
 sd_best <- as.data.frame(spectraData(ftms_msn_tree_best))
@@ -585,11 +600,15 @@ spectraData(merged_spectra) <- merged
 
 ```
 
-## MS4 spectra from other `round(`precursor_mz_MS2)` 
+## MS4 spectra from other `round(`precursor_mz_MS2)\`
 
-Identify “new” MS4 spectra in sd_filtered that aren’t already in merged trees, but are connected to existing MS3 spectra via matching precursor m/z values, and also have precursor m/z matching actual fragment peaks of those MS3 spectra.
+Identify “new” MS4 spectra in sd_filtered that aren’t already in merged
+trees, but are connected to existing MS3 spectra via matching precursor
+m/z values, and also have precursor m/z matching actual fragment peaks
+of those MS3 spectra.
 
 ###Create set of candidate new MS4 spectra
+
 ```{r}
 # Prepare subsets of the merged spectra
 merged_sd <- as.data.frame(spectraData(merged_spectra))
@@ -609,6 +628,7 @@ ms4_candidates <- sd_filtered %>%
 ```
 
 ### Retain only cadidate MS4 spectra for which the precursor m/z (precursorMz) is present among the peaks of its corresponding MS3 parent spectrum in the merged_spectra object.
+
 ```{r}
 # Identify MS3 spectra in best or merged trees, that could be parents of the candidate new MS4 spectra
 parent_ms3_precursors <- unique(ms4_candidates$precursorMz.MS2)
@@ -655,6 +675,7 @@ ms4_candidates_filtered <- ms4_candidates[keep_idx, ]
 ```
 
 ### Select MS4 candidate spectrum with highest number of peaks
+
 ```{r}
 # Create composite key precMS2.precMS3
 ms4_candidates_filtered <- ms4_candidates_filtered %>%
@@ -673,6 +694,7 @@ newms4_best <- ms4_candidates_filtered %>%
 ```
 
 ### Append new MS4 spectra (newms4_best) to merged MSntree dataset
+
 ```{r}
 # Prepare metadata for merging
 sd_merged <- as.data.frame(spectraData(merged_spectra))
@@ -710,20 +732,189 @@ spectraData(merged_spectra) <- S4Vectors::DataFrame(merged_df)
 
 ```
 
+## MS4 spectra from same `round(`precursor_mz_MS2)`, but different`round(precursorMz)\`.
 
-## MS4 spectra from same `round(`precursor_mz_MS2)`, but different `round(precursorMz)`.
+Add to merged_spectra the MS4 spectra from sd_filtered such that:
 
+(1) Their parent MS3 already exists in merged_spectra (precursorMz.MS2 %in%
+merged_spectra[msLevel == 3]$precursorMz)
 
-after selecting one representative tree per feature we have now: MS2 :
-`r ta[1]`, MS3 : `r ta[2]`, and MS4 : `r ta[3]`.
+(2) Their composite key (precMS2.precMS3) is not already present among
+existing MS4 spectra in merged_spectra
 
-Finally we verify if the number of unique features corresponds to the
-number of unique MSntreeID to ensure that we have one tree per feature.
+(3) Their precursor m/z (round(precursorMz)) is found among the rounded
+peaks of their corresponding MS3 parent spectrum in merged_spectra.
 
+### Create set of candidate new MS4 spectra
 ```{r}
-length(unique(unlist(ftms_one_tree$feature_id)))
+# Create candidate new MS4 spectra
+merged_sd <- as.data.frame(spectraData(merged_spectra))
+
+ms3_merged <- merged_sd %>% filter(msLevel == 3)
+ms4_merged <- merged_sd %>% filter(msLevel == 4)
+
+# Round precursor m/z for matching
+ms4_merged$precursorMz_round <- round(ms4_merged$precursorMz)
+ms4_merged$precursorMz_MS2_round <- round(ms4_merged$precursorMz.MS2)
+ms4_merged$precMS2.precMS3 <- paste0(
+  "precMS2_", ms4_merged$precursorMz_MS2_round,
+  "_precMS3_", ms4_merged$precursorMz_round
+)
+
+# Select MS4 candidates from sd_filtered
+ms4_candidates <- sd_filtered %>%
+  filter(
+    msLevel == 4,
+    precursorMz.MS2 %in% ms3_merged$precursorMz,                                # parent MS3 exists
+    !(paste0("precMS2_", round(precursorMz.MS2), "_precMS3_", round(precursorMz))
+      %in% ms4_merged$precMS2.precMS3)                                          # composite key not already present
+  )
+```
+
+### Retain only candidates whose precursor m/z is present among parent MS3 peaks
+```{r}
+# Identify parent MS3 spectra
+parent_ms3_precursors <- unique(ms4_candidates$precursorMz.MS2)
+ms3_parents_sd <- ms3_merged %>%
+  filter(precursorMz %in% parent_ms3_precursors)
+ms3_parents <- paste(ms3_parents_sd$dataOrigin, ms3_parents_sd$scanIndex)
+
+# Extract peaksData for relevant MS3 spectra
+pd <- peaksData(merged_spectra)
+sd <- spectraData(merged_spectra)
+spectra_id <- paste(sd$dataOrigin, sd$scanIndex)
+
+ms3_indices <- which(spectra_id %in% ms3_parents)
+peaks.ms3parents.list <- as.list(pd[ms3_indices, ])
+
+# Build lookup of rounded parent precursorMz
+parent_lookup <- lapply(peaks.ms3parents.list, function(x) round(x[, 1]))
+names(parent_lookup) <- as.character(round(ms3_parents_sd$precursorMz))
+
+# Round MS4 precursor columns for matching
+ms4_candidates <- ms4_candidates %>%
+  mutate(
+    precursorMz_round = round(precursorMz),
+    precursorMz_MS2_round = round(precursorMz.MS2)
+  )
+
+# Keep candidate if its precursor m/z is found among peaks of its corresponding MS3 parent
+keep_idx <- logical(nrow(ms4_candidates))
+for (i in seq_len(nrow(ms4_candidates))) {
+  parent_key <- as.character(ms4_candidates$precursorMz_MS2_round[i])
+  if (parent_key %in% names(parent_lookup)) {
+    keep_idx[i] <- ms4_candidates$precursorMz_round[i] %in% parent_lookup[[parent_key]]
+  } else {
+    keep_idx[i] <- FALSE
+  }
+}
+ms4_candidates_filtered <- ms4_candidates[keep_idx, ]
+```
+
+### Select best MS4 per precMS2.precMS3
+```{r}
+ms4_candidates_filtered <- ms4_candidates_filtered %>%
+  mutate(
+    precMS2.precMS3 = paste0(
+      "precMS2_", precursorMz_MS2_round,
+      "_precMS3_", precursorMz_round
+    )
+  )
+
+newms4_best <- ms4_candidates_filtered %>%
+  group_by(precMS2.precMS3) %>%
+  slice_max(order_by = peaksCount, n = 1, with_ties = FALSE) %>%
+  ungroup()
+```
+
+### Append new MS4 spectra to merged_spectra
+```{r}
+sd_merged <- as.data.frame(spectraData(merged_spectra))
+
+# Round precursor m/z for consistency
+sd_merged$precMzRound <- round(sd_merged$precursorMz)
+newms4_best$precMzRound <- round(newms4_best$precursorMz)
+
+# Create merge keys
+mergeKey_existing <- paste(sd_merged$dataOrigin, sd_merged$scanIndex, sep = "_")
+mergeKey_newms4   <- paste(newms4_best$dataOrigin, newms4_best$scanIndex, sep = "_")
+
+# Combine metadata tables
+common_cols <- intersect(names(sd_merged), names(newms4_best))
+merged_df <- bind_rows(
+  sd_merged[, common_cols],
+  newms4_best[, common_cols]
+)
+
+# Assign new merged tree IDs
+merged_df <- merged_df %>%
+  mutate(MergedMSntreeID = as.integer(factor(feature_id)))
+
+# Update Spectra object
+original_sd <- as.data.frame(spectraData(ftms_msn_tree))
+original_key <- paste(original_sd$dataOrigin, original_sd$scanIndex, sep = "_")
+
+merged_spectra <- ftms_msn_tree[original_key %in% c(mergeKey_existing, mergeKey_newms4)]
+spectraData(merged_spectra) <- S4Vectors::DataFrame(merged_df)
 
 ```
+
+# Check MS levels in merged MSn trees
+
+
+Finally we verify if the number of unique features corresponds to the
+number of unique MergedMSntreeID to ensure that we have one tree per feature.
+
+```{r}
+length(unique(unlist(merged_spectra$feature_id)))
+length(unique(unlist(merged_spectra$MergedMSntreeID)))
+length(unique(unlist(merged_spectra$MSntreeID)))
+
+# Extract spectraData from merged_spectra
+merged_sd <- as.data.frame(spectraData(merged_spectra))
+
+# Count spectra per feature : MS level
+feature_counts <- table(merged_sd$feature_id, merged_sd$msLevel)
+feature_counts <- as.data.frame.matrix(feature_counts)  # columns = MS levels
+
+# Define MS levels present
+ms_levels <- colnames(feature_counts)
+
+# Compute summary for each MS level with descriptive names
+ms_summary <- lapply(ms_levels, function(ms) {
+  counts <- feature_counts[[ms]]
+  summary(counts)
+})
+
+# Set descriptive names
+names(ms_summary) <- paste0("MS", ms_levels, " spectra per feature")
+
+# Print summaries
+ms_summary
+```
+
+## inspect merged MSn tree with 6 MS3 spectra
+```{r}
+
+merged_sd <- as.data.frame(spectraData(merged_spectra))
+
+# Identify features with exactly three MS3 spectra
+features_6MS3 <- merged_sd %>%
+  filter(msLevel == 3) %>%
+  group_by(feature_id) %>%
+  summarise(n_MS3 = n(), .groups = "drop") %>%
+  filter(n_MS3 == 6) %>%
+  pull(feature_id)
+
+# Subset merged_spectra for these feature(s)
+merged_subset <- merged_spectra[merged_sd$feature_id %in% features_6MS3]
+
+# Optional: show metadata of the subset
+as.data.frame(spectraData(merged_subset))
+```
+
+# Post-processing
+among groups of spectra with the same feature_id, msLevel, precMz, precMz.MS2, keep only spectrum with highest peaksCount
 
 ```{r}
 length(unique(ftms_one_tree$MSntreeID))

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -44,8 +44,6 @@ load(file.path(pth, "data", "ftms.RData"))
 class(ftms)
 ```
 
-
-
 ```{r}
 ftms
 library(Spectra)
@@ -53,6 +51,7 @@ library(Spectra)
 sp <- spectra(ftms)
 
 ```
+
 # Associate MS2 spectra to features
 
 Next, we use `xcms::featureSpectra()` to extract all MS2 spectra for
@@ -71,11 +70,8 @@ msLevel(ms2) |>
   table()
 ```
 
-
-
-
-it returns `r length(ms2)` MS level 2 spectra. The total number of features for
-which an MS2 spectrum was identified is:
+it returns `r length(ms2)` MS level 2 spectra. The total number of
+features for which an MS2 spectrum was identified is:
 
 ```{r}
 length(unique(ms2$feature_id))
@@ -89,12 +85,10 @@ s <- spectra(ftms)
 table(msLevel(s))
 ```
 
-
-
-
-In total, there were `r table(msLevel(s))[2]` MS2 spectra. This means that `r round((table(msLevel(s))[2]-length(ms2$feature_id))*100/table(msLevel(s))[2], 1)` % of the MS2
-spectra could not be assigned to any chromatographic peak.
-
+In total, there were `r table(msLevel(s))[2]` MS2 spectra. This means
+that
+`r round((table(msLevel(s))[2]-length(ms2$feature_id))*100/table(msLevel(s))[2], 1)`
+% of the MS2 spectra could not be assigned to any chromatographic peak.
 
 The percentage of features with at least one MS2:
 
@@ -111,8 +105,9 @@ perc_features_with_ms2
 
 ```
 
-The total number of features with at least one MS2 is `r n_features_with_ms2`,
-which corresponds to `r format(perc_features_with_ms2, digits = 3)`%.
+The total number of features with at least one MS2 is
+`r n_features_with_ms2`, which corresponds to
+`r format(perc_features_with_ms2, digits = 3)`%.
 
 A summary on the number of MS2 spectra assigned to a feature is shown
 below:
@@ -142,7 +137,8 @@ perc_ms2_assigned
 ```
 
 The total number of assigned MS2 spectra is `r n_assigned_ms2`, which
-corresponds to a percentage of `r format(perc_ms2_assigned, digits = 3)`.
+corresponds to a percentage of
+`r format(perc_ms2_assigned, digits = 3)`.
 
 Note that an MS2 spectrum could also be assigned to more than one
 feature. The total number of MS2 spectra assigned to more than one
@@ -155,9 +151,8 @@ ms2_mult <- names(ms2_table)[ms2_table > 1]
 
 ```
 
-Of the `r length(unique(ms2_id))` MS2 spectra, `r length(ms2_mult)` are assigned
-to more than one feature. 
-
+Of the `r length(unique(ms2_id))` MS2 spectra, `r length(ms2_mult)` are
+assigned to more than one feature.
 
 # Extract all MS2-MSn spectra associated to features
 
@@ -211,8 +206,8 @@ table(msLevel(ftms_msn_tree))
 
 # Grouping MSn spectra into fragmentation trees
 
-We next need to group all MSn spectra from one fragmentation tree
-together.
+We now group all spectra that belong to the same fragmentation tree and record the precursor m/z of the originating MS2 spectrum for each spectrum within that tree.
+
 
 The function `assign_msntree_id()` will:
 
@@ -220,16 +215,18 @@ The function `assign_msntree_id()` will:
 -   Assign tree IDs to each spectrum in `x`, based on precursor
     relationships within each sample (`dataOrigin`)\
 -   Ensure that MS2 spectra always start a new tree, and that MS3/MS4
-    spectra inherit the tree ID from their parent
--   Return a vector of integers, the same length as the number of
-    spectra in `x`, where each integer represents the fragmentation tree
-    ID the spectrum belongs to
+    spectra inherit the tree ID from their parent\
+-   Propagate the MS2-level precursor m/z to all downstream spectra in
+    the same tree (MS3, MS4, …), with `NA` for MS2 spectra\
+-   Return the updated `Spectra` object with two new spectra variables:
 
-The output of the `assign_msntree_id()` function is then added to the
-`Spectra` object as a new spectra variable *MSntreeID*.
+    -   **`MSntreeID`** — integer ID of the fragmentation tree each
+        spectrum belongs to\
+    -   **`precursorMz.MS2`** — MS2-level precursor m/z propagated to
+        MS3/MS4 (and beyond), `NA` for MS2
+        
 
 ```{r}
-
 assign_msntree_id <- function(x) {
   ## Order x by MS level: ensures we first assign an ID to the MS2.
   o <- order(msLevel(x))
@@ -238,8 +235,14 @@ assign_msntree_id <- function(x) {
   prec_scan_num <- precScanNum(x)
   ms_level <- msLevel(x)
   data_origin <- dataOrigin(x)
+  
+  ## store precursorMz values
+  precursor_mz <- precursorMz(x)
 
   tree_id <- rep(NA_integer_, length(scan_index))
+  ## initialize output vector for MS2-level precursor m/z
+  precursor_mz_MS2 <- rep(NA_real_, length(scan_index))
+  
   global_counter <- 0
 
   for (origin in unique(data_origin)) {
@@ -247,7 +250,11 @@ assign_msntree_id <- function(x) {
     origin_scan_index <- scan_index[idx]
     origin_prec_scan_num <- prec_scan_num[idx]
     origin_ms_level <- ms_level[idx]
+    ## per-origin precursorMz vector
+    origin_precursor_mz <- precursor_mz[idx]
     origin_tree_id <- rep(NA_integer_, length(idx))
+    ## per-origin precursorMz.MS2 vector
+    origin_precursor_mz_MS2 <- rep(NA_real_, length(idx))
 
     scan_idx_map <- setNames(seq_along(origin_scan_index), origin_scan_index)
 
@@ -259,36 +266,79 @@ assign_msntree_id <- function(x) {
           global_counter <- global_counter + 1
           origin_tree_id[i] <- global_counter
         }
+        ## 🔹 NEW: MS2 spectra have no MS2-level precursor
+        origin_precursor_mz_MS2[i] <- NA_real_
+
       } else {
         ## Assign ID of the related precursor ID
         parent_scan <- origin_prec_scan_num[i]
         parent_pos <- scan_idx_map[as.character(parent_scan)]
-        if (length(parent_pos) == 1 && origin_ms_level[parent_pos] == (level - 1))
+        if (length(parent_pos) == 1 && origin_ms_level[parent_pos] == (level - 1)) {
           origin_tree_id[i] <- origin_tree_id[parent_pos]
-        else
+
+          ## assign precursorMz.MS2 depending on depth
+          if (level == 3) {
+            ## MS3: parent is MS2 → use parent’s precursorMz
+            origin_precursor_mz_MS2[i] <- origin_precursor_mz[parent_pos]
+          } else if (level == 4) {
+            ## MS4: grandparent is MS2 → fetch its precursorMz
+            grandparent_scan <- origin_prec_scan_num[parent_pos]
+            grandparent_pos <- scan_idx_map[as.character(grandparent_scan)]
+            if (length(grandparent_pos) == 1 && origin_ms_level[grandparent_pos] == 2)
+              origin_precursor_mz_MS2[i] <- origin_precursor_mz[grandparent_pos]
+            else
+              origin_precursor_mz_MS2[i] <- NA_real_
+          } else {
+            ## Optional: handle MS5+ recursively (rare)
+            ancestor_pos <- parent_pos
+            while (ancestor_pos > 0 &&
+                   origin_ms_level[ancestor_pos] > 2) {
+              parent_scan <- origin_prec_scan_num[ancestor_pos]
+              ancestor_pos <- scan_idx_map[as.character(parent_scan)]
+            }
+            if (!is.na(ancestor_pos) && origin_ms_level[ancestor_pos] == 2)
+              origin_precursor_mz_MS2[i] <- origin_precursor_mz[ancestor_pos]
+            else
+              origin_precursor_mz_MS2[i] <- NA_real_
+          }
+
+        } else {
           stop("MS", level, " with ", length(parent_pos), " precursors")
+        }
       }
     }
     tree_id[idx] <- origin_tree_id
+    ## store per-origin results
+    precursor_mz_MS2[idx] <- origin_precursor_mz_MS2
   }
+
   ## Return in original order
-  return(tree_id[order(o)])
+  tree_id <- tree_id[order(o)]
+  ## reorder new variable to match
+  precursor_mz_MS2 <- precursor_mz_MS2[order(o)]
+
+  ## add both to Spectra object
+  x$MSntreeID <- tree_id
+  x$precursorMz.MS2 <- precursor_mz_MS2
+
+  return(x)
 }
 
-msntree_ids <- assign_msntree_id(ftms_msn_tree)
 
-ftms_msn_tree$MSntreeID <- msntree_ids
+ftms_msn_tree <- assign_msntree_id(ftms_msn_tree)
+
 spectraVariables(ftms_msn_tree)
 
 ```
-
 
 ```{r}
 length(unique(ftms_msn_tree$MSntreeID))
 ```
 
-There are in total `r length(unique(ftms_msn_tree$MSntreeID))` spectral (fragmentation) trees for in total `r length(unique(ftms_msn_tree$feature_id))` features. The
-distribution of the lengths of the fragmentation trees is
+There are in total `r length(unique(ftms_msn_tree$MSntreeID))` spectral
+(fragmentation) trees for in total
+`r length(unique(ftms_msn_tree$feature_id))` features. The distribution
+of the lengths of the fragmentation trees is
 
 ```{r}
 ftms_msn_tree$MSntreeID |>
@@ -298,11 +348,15 @@ ftms_msn_tree$MSntreeID |>
 table(table(ftms_msn_tree$MSntreeID))
 ```
 
-Fragmentation trees have maximally 4 spectra. 
-This is in accordance with the setup of the ion trap instrument: The two most intense first order product ions were refragmented (if their intensity was above a threshold), resulting in maximally two MS3 spectra, and the most intense second order product ion of the most intense first order product ion was also refragmented (if it's intensity was above a threshold), resulting in maximally one MS4 spectrum.
-So, a fragmentation tree can maximally consist of one MS2 spectrum + two MS3 spectra + one MS4 spectrum = four spectra.
-
-
+Fragmentation trees have maximally 4 spectra. This is in accordance with
+the setup of the ion trap instrument: The two most intense first order
+product ions were refragmented (if their intensity was above a
+threshold), resulting in maximally two MS3 spectra, and the most intense
+second order product ion of the most intense first order product ion was
+also refragmented (if it's intensity was above a threshold), resulting
+in maximally one MS4 spectrum. So, a fragmentation tree can maximally
+consist of one MS2 spectrum + two MS3 spectra + one MS4 spectrum = four
+spectra.
 
 ```{r}
 ## we stored the tree ids and the msLevels to a dataframe
@@ -321,16 +375,21 @@ print(t <- table(max_level_per_tree$max_level))
 ```
 
 The number of trees that go up to MS2 level is : `r t[1]`. The number of
-trees that go up to MS3 level is : `r t[2]`. The number of trees that go up to
-MS4 level is : `r t[3]`.
+trees that go up to MS3 level is : `r t[2]`. The number of trees that go
+up to MS4 level is : `r t[3]`.
 
 # Select single best MSn spectral tree per feature
 
-
-Next we select one most representative tree per feature based on (1) the intensity of the precursor, (2) the length of the tree, (3) the total number of peaks in all spectra of the tree, and (4) in rare cases of several trees with maximal number of peaks: break ties based on precursor intensity (max)
+Next we select one most representative tree per feature based on (1) the
+intensity of the precursor, (2) the length of the tree, (3) the total
+number of peaks in all spectra of the tree, and (4) in rare cases of
+several trees with maximal number of peaks: break ties based on
+precursor intensity (max)
 
 ## (1) Filter out weak precursor trees (lowest precursor intensity)
-Keep only trees (`vMSntreeID`v) whose `msLevel == 2` spectrum precursor intensity is in the top 75%.
+
+Keep only trees (`vMSntreeID`v) whose `msLevel == 2` spectrum precursor
+intensity is in the top 75%.
 
 ```{r}
 sd <- as.data.frame(spectraData(ftms_msn_tree))
@@ -340,8 +399,8 @@ strong_MSntrees <- unique(ms2$MSntreeID[ms2$precursorIntensity > threshold])
 sd_filtered <- subset(sd, MSntreeID %in% strong_MSntrees)
 ```
 
-
 ## (2) Among 75% remaining MSn trees, select the longest tree per feature
+
 ```{r}
 # Get max msLevel per tree
 tree_length <- aggregate(msLevel ~ MSntreeID + feature_id, data = sd_filtered, max)
@@ -354,8 +413,8 @@ longest_trees <- merge(tree_length, max_len, by = c("feature_id", "msLevel"))
 
 ```
 
-
 ## (3) select the tree with highest total number of peaks in all levels
+
 total number of peaks: sum of peaksCount per tree_id in spectraData
 
 ```{r}
@@ -368,6 +427,7 @@ candidate_trees <- merge(candidate_trees, max_peaks, by.x = c("feature_id", "pea
 ```
 
 ## (4) break ties by precursor intensity (highest)
+
 ```{r}
 # Compute maximal precursor intensity of MS2 spectra per tree
 prec_max <- aggregate(precursorIntensity ~ MSntreeID, data = ms2, max)
@@ -379,12 +439,14 @@ best_tree <- candidate_trees[!duplicated(candidate_trees$feature_id), c("feature
 ```
 
 ## (5) filter Spectra object
+
 ```{r}
 best_MSntreeIDs <- best_tree$MSntreeID
 ftms_msn_tree_best <- ftms_msn_tree[ which(spectraData(ftms_msn_tree)$MSntreeID %in% best_MSntreeIDs) ]
 ```
 
 ## (6) (Optional) evaluate based on known spectra
+
 ```{r}
 idx <- which(round(ftms_msn_tree_best$precursorMz) == 1333)
 idx
@@ -396,14 +458,16 @@ idx
 peaksData(ftms_msn_tree_best)[idx][[1]]
 peaksData(ftms_msn_tree_best)[idx][[2]]
 ```
+
 This looks like a really good selection !
 
 # Add additional MS3 and MS4 spectra, with different precursorMz, to the selected trees
 
-Here, the purpose is to add, from the "strong" spectral trees with MS2 precursorMz in top 75 %, MS3 spectra with different MS2 precursorMz, and MS4 spectra with different MS3 or MS4 precursorMz, to the selected `ftms_msn_tree_best`. I would select again based on peakCOunts and, if ties, precursorIntensity.
-
-
-
+Here, the purpose is to add, from the "strong" spectral trees with MS2
+precursorMz in top 75 %, MS3 spectra with different MS2 precursorMz, and
+MS4 spectra with different MS3 or MS4 precursorMz, to the selected
+`ftms_msn_tree_best`. I would select again based on peakCOunts and, if
+ties, precursorIntensity.
 
 after selecting one representative tree per feature we have now: MS2 :
 `r ta[1]`, MS3 : `r ta[2]`, and MS4 : `r ta[3]`.
@@ -420,8 +484,9 @@ length(unique(unlist(ftms_one_tree$feature_id)))
 length(unique(ftms_one_tree$MSntreeID))
 ```
 
-we have `r length(unique(ftms_one_tree$MSntreeID))` unique feature and unique MSntreeID, That's mean that we
-have for each feature one representative tree.
+we have `r length(unique(ftms_one_tree$MSntreeID))` unique feature and
+unique MSntreeID, That's mean that we have for each feature one
+representative tree.
 
 Now we save the resulting ftms spectra object to a local directory.
 
@@ -441,23 +506,20 @@ tst$dataOrigin
 ```{r}
 peaksData(ftms_one_tree)[spectraData(ftms_one_tree)$feature_id == "FT5291" & spectraData(ftms_one_tree)$msLevel == 2,][[1,]]
 ```
+
 ```{r}
 peaksData(ftms_one_tree)[spectraData(ftms_one_tree)$scanIndex == "FT5341" &
                   spectraData(ftms_one_tree)$msLevel == 2,][[1,]]
 ```
 
-
 ```{r}
 spectraData(ftms_one_tree)
 ```
-
 
 ```{r}
 spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$feature_id == "FT0066", ]
 
 ```
-
-
 
 # Session information
 

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -393,6 +393,13 @@ ms2 <- subset(sd, msLevel == 2)
 threshold <- quantile(ms2$precursorIntensity, 0.25, na.rm = TRUE)
 strong_MSntrees <- unique(ms2$MSntreeID[ms2$precursorIntensity > threshold])
 sd_filtered <- subset(sd, MSntreeID %in% strong_MSntrees)
+
+length(unique(sd_filtered$feature_id))
+length(unique(sd$feature_id)) 
+removed.features <- length(unique(sd$feature_id)) - length(unique(sd_filtered$feature_id))
+message(removed.features, " features were removed after selecting only spectra with top 75% precursor intensity.")
+message(length(unique(sd_filtered$feature_id))," of the ", length(unique(sd$feature_id)), " features remain.")
+
 ```
 
 ## (2) Among 75% remaining MSn trees, select the longest tree per feature
@@ -487,6 +494,13 @@ peaksData(ftms_msn_tree_best)[idx][[2]]
 ```
 
 This looks like a really good selection !
+## (6) Save
+Now we save the resulting ftms spectra object to a local directory.
+
+```{r}
+ftms_one_tree <- ftms_msn_tree_best
+save(ftms_one_tree, file = file.path(pth, "data", "ftms_one_tree.RData"))
+```
 
 # Add additional MS3 and MS4 spectra, with different precursorMz, to the selected trees
 
@@ -619,15 +633,13 @@ merged <- merged %>%
   mutate(MergedMSntreeID = as.integer(factor(feature_id)))
 
 # Extract and update the corresponding spectra from the original MSn tree object
-mergeKey <- paste(merged$dataOrigin, merged$scanIndex, sep = "_")
+merged_spectra <- ftms_msn_tree[
+  paste(spectraData(ftms_msn_tree)$dataOrigin,
+        spectraData(ftms_msn_tree)$scanIndex, sep = "_") %in%
+    paste(merged$dataOrigin, merged$scanIndex, sep = "_")
+]
 
-original_key <- paste(spectraData(ftms_msn_tree)$dataOrigin,
-                      spectraData(ftms_msn_tree)$scanIndex,
-                      sep = "_")
-
-merged_spectra <- ftms_msn_tree[original_key %in% mergeKey]
-merged <- S4Vectors::DataFrame(merged)
-spectraData(merged_spectra) <- merged
+spectraData(merged_spectra) <- S4Vectors::DataFrame(merged)
 
 ```
 ### Check for duplicates and post-processing if duplicates found
@@ -820,14 +832,12 @@ merged_df <- merged_df %>%
   mutate(MergedMSntreeID = as.integer(factor(feature_id)))
 
 # Update Spectra object
-# Locate spectra in original Spectra object
-original_sd <- as.data.frame(spectraData(ftms_msn_tree))  
-original_key <- paste(original_sd$dataOrigin, original_sd$scanIndex, sep = "_")
+merged_spectra <- ftms_msn_tree[
+  paste(spectraData(ftms_msn_tree)$dataOrigin,
+        spectraData(ftms_msn_tree)$scanIndex, sep = "_") %in%
+    c(mergeKey_existing, mergeKey_newms4)
+]
 
-# Subset original spectra that match the merged table
-merged_spectra <- ftms_msn_tree[original_key %in% c(mergeKey_existing, mergeKey_newms4)]
-
-# Replace spectraData with updated merged table
 spectraData(merged_spectra) <- S4Vectors::DataFrame(merged_df)
 
 ```
@@ -1010,10 +1020,12 @@ merged_df <- merged_df %>%
   mutate(MergedMSntreeID = as.integer(factor(feature_id)))
 
 # Update Spectra object
-original_sd <- as.data.frame(spectraData(ftms_msn_tree))
-original_key <- paste(original_sd$dataOrigin, original_sd$scanIndex, sep = "_")
+merged_spectra <- ftms_msn_tree[
+  paste(spectraData(ftms_msn_tree)$dataOrigin,
+        spectraData(ftms_msn_tree)$scanIndex, sep = "_") %in%
+    c(mergeKey_existing, mergeKey_newms4)
+]
 
-merged_spectra <- ftms_msn_tree[original_key %in% c(mergeKey_existing, mergeKey_newms4)]
 spectraData(merged_spectra) <- S4Vectors::DataFrame(merged_df)
 
 ```
@@ -1105,15 +1117,16 @@ representative tree.
 Now we save the resulting ftms spectra object to a local directory.
 
 ```{r}
-save(merged_spectra, file = file.path(pth, "data", "ftms_one_tree.RData"))
+ftms_one_merged_tree <- merged_spectra
+save(ftms_one_merged_tree, file = file.path(pth, "data", "ftms_one_merged_tree.RData"))
 ```
 
 ```{r}
-load("data/ftms_one_tree.RData")
+load("data/ftms_one_merged_tree.RData")
 ```
 
 ```{r}
-tst <- spectraData(ftms_one_tree)[spectraData(ftms_one_tree)$feature_id == "FT5291",]
+tst <- spectraData(ftms_one_merged_tree)[spectraData(ftms_one_merged_tree)$feature_id == "FT5291",]
 tst$dataOrigin
 ```
 

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -396,6 +396,36 @@ sd_filtered <- subset(sd, MSntreeID %in% strong_MSntrees)
 ```
 
 ## (2) Among 75% remaining MSn trees, select the longest tree per feature
+### Remove duplicates after rounding of precursorMz
+MS2, MS3, and MS4 spectra have unit resolution. This means that, within the same dataOrigin, MS3 spectra with the same round(precursorMz), and same precursorIntensity, are duplicates. Of these duplicates we only retain the MS3 spectrum with the highest value for peaksCount
+```{r}
+# Round precursor m/z for unit resolution matching
+sd_filtered <- sd_filtered %>%
+  mutate(precursorMz_round = round(precursorMz))
+
+# Identify duplicates only among MS3 spectra
+ms3_filtered <- sd_filtered %>%
+  filter(msLevel == 3)
+
+# Deduplicate: within each dataOrigin, precursorMz_round, precursorIntensity group
+ms3_dedup <- ms3_filtered %>%
+  group_by(dataOrigin, precursorMz_round, precursorIntensity) %>%
+  slice_max(order_by = peaksCount, n = 1, with_ties = FALSE) %>%
+  ungroup()
+
+# Replace MS3 spectra in the full dataset with deduplicated ones
+sd_filtered_dedup <- bind_rows(
+  sd_filtered %>% filter(msLevel != 3),
+  ms3_dedup
+)
+
+# message summary
+removed <- nrow(sd_filtered) - nrow(sd_filtered_dedup)
+message(removed, " duplicate MS3 spectra removed after rounding and deduplication.")
+
+sd_filtered <- sd_filtered_dedup
+```
+### Select longest tree per feature
 
 ```{r}
 # Get max msLevel per tree
@@ -441,7 +471,8 @@ best_MSntreeIDs <- best_tree$MSntreeID
 ftms_msn_tree_best <- ftms_msn_tree[ which(spectraData(ftms_msn_tree)$MSntreeID %in% best_MSntreeIDs) ]
 ```
 
-## (6) (Optional) evaluate based on known spectra
+
+## (Optional) evaluate based on known spectra
 
 ```{r}
 idx <- which(round(ftms_msn_tree_best$precursorMz) == 1333)
@@ -599,6 +630,31 @@ merged <- S4Vectors::DataFrame(merged)
 spectraData(merged_spectra) <- merged
 
 ```
+### Check for duplicates and post-processing if duplicates found
+
+```{r}
+# Extract metadata
+merged_sd <- as.data.frame(spectraData(merged_spectra))
+
+# Identify groups with same feature_id, msLevel, precursorMz, precursorMz.MS2
+merged_sd_MS4 <- merged_sd[merged_sd$msLevel == 4,]
+merged_sd_MS4$precMz.MS2.Round <- round(merged_sd_MS4$precursorMz.MS2)
+dup_groups <- merged_sd_MS4 %>%
+  group_by(feature_id, msLevel, precMzRound, precMz.MS2.Round) %>%
+  mutate(n_in_group = n()) %>%
+  ungroup() %>%
+  filter(n_in_group > 1)
+
+# Report duplicates
+if (nrow(dup_groups) > 0) {
+  message("Found ", nrow(dup_groups), " spectra in duplicate groups:")
+dup_groups_ordered <- dup_groups %>%
+    arrange(feature_id)
+  
+  print(dup_groups_ordered[, c("feature_id","msLevel","precMz.MS2.Round","precMzRound","peaksCount")])} else {
+  message("No duplicate MS4 spectra found.")
+}
+```
 
 ## MS4 spectra from other `round(`precursor_mz_MS2)\`
 
@@ -674,23 +730,67 @@ for (i in seq_len(nrow(ms4_candidates))) {
 ms4_candidates_filtered <- ms4_candidates[keep_idx, ]
 ```
 
+### Check for duplicate MS4 spectra and remove if necessary
+```{r}
+# Prepare merged_spectra metadata for comparison
+merged_sd <- as.data.frame(spectraData(merged_spectra)) %>%
+  mutate(
+    precursorMz_round = round(precursorMz),
+    precursorMz_MS2_round = round(precursorMz.MS2)
+  )
+
+# Build unique composite keys for existing merged spectra and MS4 candidates
+existing_keys <- paste(
+  merged_sd$feature_id,
+  merged_sd$msLevel,
+  merged_sd$precursorMz_round,
+  merged_sd$precursorMz_MS2_round,
+  sep = "_"
+)
+
+candidate_keys <- paste(
+  ms4_candidates_filtered$feature_id,
+  ms4_candidates_filtered$msLevel,
+  ms4_candidates_filtered$precursorMz_round,
+  ms4_candidates_filtered$precursorMz_MS2_round,
+  sep = "_"
+)
+
+# Retain only candidates whose key is NOT already in merged_spectra
+keep_new_idx <- !(candidate_keys %in% existing_keys)
+ms4_candidates_filtered <- ms4_candidates_filtered[keep_new_idx, ]
+
+message(sum(!keep_new_idx), " candidate MS4 spectra removed because they already exist in merged_spectra.")
+message(nrow(ms4_candidates_filtered), " unique new MS4 spectra retained.")
+```
+
 ### Select MS4 candidate spectrum with highest number of peaks
 
 ```{r}
 # Create composite key precMS2.precMS3
 ms4_candidates_filtered <- ms4_candidates_filtered %>%
   mutate(
-    precMS2.precMS3 = paste0(
+    ft.precMS2.precMS3 = paste0(
+      feature_id,
       "precMS2_", round(precursorMz.MS2),
       "_precMS3_", round(precursorMz)
     )
   )
 
-# Keep only MS4 spectrum with the highest number of peaks per unique precMS2.precMS3
-newms4_best <- ms4_candidates_filtered %>%
-  group_by(precMS2.precMS3) %>%
-  slice_max(order_by = peaksCount, n = 1, with_ties = FALSE) %>%
-  ungroup()
+group_sizes <- ms4_candidates_filtered %>%
+  count(ft.precMS2.precMS3)
+
+
+# Keep only MS4 spectrum with the highest number of peaks per unique ft.precMS2.precMS3
+if (all(group_sizes$n == 1)) {
+  message("Each ft.precMS2.precMS3 group has only one row — skipping slice_max() step.")
+  newms4_best <- ms4_candidates_filtered
+} else {
+  newms4_best <- ms4_candidates_filtered %>%
+    group_by(ft.precMS2.precMS3) %>%
+    slice_max(order_by = peaksCount, n = 1, with_ties = FALSE) %>%
+    ungroup()
+}
 ```
 
 ### Append new MS4 spectra (newms4_best) to merged MSntree dataset
@@ -730,6 +830,32 @@ merged_spectra <- ftms_msn_tree[original_key %in% c(mergeKey_existing, mergeKey_
 # Replace spectraData with updated merged table
 spectraData(merged_spectra) <- S4Vectors::DataFrame(merged_df)
 
+```
+
+### Check for duplicates (and post-processing if duplicates found)
+
+```{r}
+# Extract metadata
+merged_sd <- as.data.frame(spectraData(merged_spectra))
+
+# Identify MS4 spectra with same feature_id, msLevel, precursorMz, precursorMz.MS2
+merged_sd_MS4 <- merged_sd[merged_sd$msLevel == 4,]
+merged_sd_MS4$precMz.MS2.Round <- round(merged_sd_MS4$precursorMz.MS2)
+dup_groups <- merged_sd_MS4 %>%
+  group_by(feature_id, msLevel, precMzRound, precMz.MS2.Round) %>%
+  mutate(n_in_group = n()) %>%
+  ungroup() %>%
+  filter(n_in_group > 1)
+
+# Report duplicates
+if (nrow(dup_groups) > 0) {
+  message("Found ", nrow(dup_groups), " spectra in duplicate groups:")
+dup_groups_ordered <- dup_groups %>%
+    arrange(feature_id)
+  
+  print(dup_groups_ordered[, c("feature_id","msLevel","precMzRound","precMz.MS2.Round","peaksCount")])} else {
+  message("No duplicate spectra found.")
+}
 ```
 
 ## MS4 spectra from same `round(`precursor_mz_MS2)`, but different`round(precursorMz)\`.
@@ -811,6 +937,39 @@ for (i in seq_len(nrow(ms4_candidates))) {
 ms4_candidates_filtered <- ms4_candidates[keep_idx, ]
 ```
 
+### Check for duplicate MS4 spectra and remove if necessary
+```{r}
+# Prepare merged_spectra metadata for comparison
+merged_sd <- as.data.frame(spectraData(merged_spectra)) %>%
+  mutate(
+    precursorMz_round = round(precursorMz),
+    precursorMz_MS2_round = round(precursorMz.MS2)
+  )
+
+# Build unique composite keys for existing merged spectra and MS4 candidates
+existing_keys <- paste(
+  merged_sd$feature_id,
+  merged_sd$msLevel,
+  merged_sd$precursorMz_round,
+  merged_sd$precursorMz_MS2_round,
+  sep = "_"
+)
+
+candidate_keys <- paste(
+  ms4_candidates_filtered$feature_id,
+  ms4_candidates_filtered$msLevel,
+  ms4_candidates_filtered$precursorMz_round,
+  ms4_candidates_filtered$precursorMz_MS2_round,
+  sep = "_"
+)
+
+# Retain only candidates whose key is NOT already in merged_spectra
+keep_new_idx <- !(candidate_keys %in% existing_keys)
+ms4_candidates_filtered <- ms4_candidates_filtered[keep_new_idx, ]
+
+message(sum(!keep_new_idx), " candidate MS4 spectra removed because they already exist in merged_spectra.")
+message(nrow(ms4_candidates_filtered), " unique new MS4 spectra retained.")
+```
 ### Select best MS4 per precMS2.precMS3
 ```{r}
 ms4_candidates_filtered <- ms4_candidates_filtered %>%
@@ -859,17 +1018,34 @@ spectraData(merged_spectra) <- S4Vectors::DataFrame(merged_df)
 
 ```
 
-# Check MS levels in merged MSn trees
-
-
-Finally we verify if the number of unique features corresponds to the
-number of unique MergedMSntreeID to ensure that we have one tree per feature.
+### Check for duplicates and post-processing if duplicates found
 
 ```{r}
-length(unique(unlist(merged_spectra$feature_id)))
-length(unique(unlist(merged_spectra$MergedMSntreeID)))
-length(unique(unlist(merged_spectra$MSntreeID)))
+# Extract metadata
+merged_sd <- as.data.frame(spectraData(merged_spectra))
 
+# Identify groups with same feature_id, msLevel, precursorMz, precursorMz.MS2
+merged_sd_MS4 <- merged_sd[merged_sd$msLevel == 4,]
+merged_sd_MS4$precMz.MS2.Round <- round(merged_sd_MS4$precursorMz.MS2)
+dup_groups <- merged_sd_MS4 %>%
+  group_by(feature_id, msLevel, precMzRound, precMz.MS2.Round) %>%
+  mutate(n_in_group = n()) %>%
+  ungroup() %>%
+  filter(n_in_group > 1)
+
+# Report duplicates
+if (nrow(dup_groups) > 0) {
+  message("Found ", nrow(dup_groups), " spectra in duplicate groups:")
+dup_groups_ordered <- dup_groups %>%
+    arrange(feature_id)
+  
+  print(dup_groups_ordered[, c("feature_id","msLevel","precMz.MS2.Round","precMzRound","peaksCount")])} else {
+  message("No duplicate MS4 spectra found.")
+}
+```
+# Check MS levels in merged MSn trees
+
+```{r}
 # Extract spectraData from merged_spectra
 merged_sd <- as.data.frame(spectraData(merged_spectra))
 
@@ -893,41 +1069,43 @@ names(ms_summary) <- paste0("MS", ms_levels, " spectra per feature")
 ms_summary
 ```
 
-## inspect merged MSn tree with 6 MS3 spectra
+## inspect merged MSn tree with 5 MS3 spectra
 ```{r}
 
 merged_sd <- as.data.frame(spectraData(merged_spectra))
 
 # Identify features with exactly three MS3 spectra
-features_6MS3 <- merged_sd %>%
+features_5MS3 <- merged_sd %>%
   filter(msLevel == 3) %>%
   group_by(feature_id) %>%
   summarise(n_MS3 = n(), .groups = "drop") %>%
-  filter(n_MS3 == 6) %>%
+  filter(n_MS3 == 5) %>%
   pull(feature_id)
 
 # Subset merged_spectra for these feature(s)
-merged_subset <- merged_spectra[merged_sd$feature_id %in% features_6MS3]
-
-# Optional: show metadata of the subset
+merged_subset <- merged_spectra[merged_sd$feature_id == features_5MS3[[1]]]
 as.data.frame(spectraData(merged_subset))
 ```
 
-# Post-processing
-among groups of spectra with the same feature_id, msLevel, precMz, precMz.MS2, keep only spectrum with highest peaksCount
 
+#Save
+
+Finally we verify if the number of unique features corresponds to the
+number of unique MergedMSntreeID to ensure that we have one tree per feature.
 ```{r}
-length(unique(ftms_one_tree$MSntreeID))
+length(unique(unlist(merged_spectra$feature_id)))
+length(unique(unlist(merged_spectra$MergedMSntreeID)))
+length(unique(unlist(merged_spectra$MSntreeID)))
 ```
 
-we have `r length(unique(ftms_one_tree$MSntreeID))` unique feature and
+we have `r length(unique(merged_spectra$MergedMSntreeID))` unique feature and
 unique MSntreeID, That's mean that we have for each feature one
 representative tree.
 
 Now we save the resulting ftms spectra object to a local directory.
 
 ```{r}
-save(ftms_one_tree, file = file.path(pth, "data", "ftms_one_tree.RData"))
+save(merged_spectra, file = file.path(pth, "data", "ftms_one_tree.RData"))
 ```
 
 ```{r}

--- a/ftms_filtering.qmd
+++ b/ftms_filtering.qmd
@@ -477,43 +477,17 @@ Select longest tree (meaning MS3 with depending MS4 in the same MSntree_id)
 from these, select highest total peakCounts
 if ties, select highest precursor Intensity of MS3 spectrum
 
+### Create selectbest.ms3ms4() function:
+This function selects best MS3 spectra to be added to merged MSntree, and appends any dependent MS4 spectra from the same feature
+
 ```{r}
-#####CODE ALMOST WORKS!!!!!!!!!!!!!!!!!!!!!
-# Extract spectraData from ftms_msn_tree_best
-sd_best <- as.data.frame(spectraData(ftms_msn_tree_best))
+# Input: a dataframe with spectraData of all MS3 spectra to be added to the MSntree of a specific feature.
+# Computes total number of peaks (pc), optionally including MS4 peaks of dependent daughter MS4 spectrum.
+# Selects the best MS3 candidate based on pc score and precursor intensity.
+# Appends dependent MS4 spectrum row from sd_filtered.
 
-sd_filtered$precMzRound <- round(sd_filtered$precursorMz)
-sd_best$precMzRound <- round(sd_best$precursorMz)
 
-# Extract MS4 spectra from sd_filtered
-# ms3_acq: acquisition number of the parent MS3 spectrum
-# ms4_acq: acquisition number of the MS4 spectrum
-# peaksCount.MS4: peaksCOunt of MS4 spectrum
-ms4_spectra <- sd_filtered %>%
-  filter(msLevel == 4) %>%
-  select(MSntreeID, precScanNum, acquisitionNum, peaksCount) %>%
-  dplyr::rename(ms3_acq = precScanNum, ms4_acq = acquisitionNum, peaksCount.MS4 = peaksCount)
-
-#testfunctie3 works! : it selects the candidate MS3 with highest depth -> most total peaks -> highest precursorIntensity
-   testfunctie3 <- function(x) {
-  x %>%
-    {
-      if (any(!is.na(.$ms4_acq))) {
-        dplyr::filter(., !is.na(ms4_acq))
-        
-      } else {
-        .
-      }
-    }%>%
-    dplyr::mutate(pc = rowSums(cbind(peaksCount, peaksCount.MS4), na.rm = TRUE)) %>%
-     # sort descending by pc, then precursorIntensity
-    arrange(desc(pc), desc(precursorIntensity)) %>%
-    # keep only the top row
-    slice_head(n = 1)
-   }
-  
-   # testfunctie4: appends also, to the selected additional MS3, the depending MS4 if any
-  testfunctie4 <- function(x) {
+  selectbest.ms3ms4 <- function(x) {
   # Filter MS4 if any exist, compute pc, sort, keep top MS3
   top_ms3 <- x %>%
     {
@@ -540,6 +514,26 @@ combined <- bind_rows(top_ms3, ms4_row)
 
   combined
 } 
+```
+
+### Prepare merged MSntree dataset
+```{r}
+# Extract spectraData from ftms_msn_tree_best
+sd_best <- as.data.frame(spectraData(ftms_msn_tree_best))
+
+sd_filtered$precMzRound <- round(sd_filtered$precursorMz)
+sd_best$precMzRound <- round(sd_best$precursorMz)
+
+# Extract MS4 spectra from sd_filtered
+# ms3_acq: acquisition number of the parent MS3 spectrum
+# ms4_acq: acquisition number of the MS4 spectrum
+# peaksCount.MS4: peaksCOunt of MS4 spectrum
+ms4_spectra <- sd_filtered %>%
+  filter(msLevel == 4) %>%
+  select(MSntreeID, precScanNum, acquisitionNum, peaksCount) %>%
+  dplyr::rename(ms3_acq = precScanNum, ms4_acq = acquisitionNum, peaksCount.MS4 = peaksCount)
+
+
 # Initialize empty list to store additional MS3
 all_additional_ms3 <- list()
 
@@ -564,10 +558,10 @@ for (f in unique(sd_best$feature_id)) {
       left_join(ms4_spectra, by = c("MSntreeID" = "MSntreeID", "acquisitionNum" = "ms3_acq"))
     
   
-    # Group by precMzRound and select best MS3
+    # Group by precMzRound, select best MS3, and append MS4
 
     ms3.p.precmz <- split(ms3_candidates, ms3_candidates$precMzRound)
-    additional.ms3 <- lapply(ms3.p.precmz, testfunctie4)
+    additional.ms3 <- lapply(ms3.p.precmz, selectbest.ms3ms4)
     all_additional_ms3[[f]] <- do.call(rbind, additional.ms3)
   }
 }
@@ -589,7 +583,7 @@ merged <- bind_rows(
 merged <- merged %>%
   mutate(MergedMSntreeID = as.integer(factor(feature_id)))
 
-
+# Extract and update the corresponding spectra from the original MSn tree object
 mergeKey <- paste(merged$dataOrigin, merged$scanIndex, sep = "_")
 
 original_key <- paste(spectraData(ftms_msn_tree)$dataOrigin,
@@ -600,82 +594,8 @@ merged_spectra <- ftms_msn_tree[original_key %in% mergeKey]
 merged <- S4Vectors::DataFrame(merged)
 spectraData(merged_spectra) <- merged
 
-
 ```
-TODO: solve BUG:
-some lines are duplicated:from MSntreeID 1559, MS4 with precMzRound 545, is appended again
-> merged[merged$feature_id=="FT4198",]
-DataFrame with 8 rows and 46 columns
-    msLevel     rtime acquisitionNum scanIndex    dataStorage     dataOrigin centroided  smoothed  polarity
-  <integer> <numeric>      <integer> <integer>    <character>    <character>  <logical> <logical> <integer>
-1         2   2066.95           3568      3568 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
-2         3   2064.87           3569      3569 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
-3         3   2065.19           3570      3570 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
-4         4   2065.51           3571      3571 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
-5         4   2064.52           3571      3571 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
-6         4   2065.51           3571      3571 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
-7         3   2062.21           3566      3566 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
-8         3   2067.24           3507      3507 D:\\RDynLib... D:\\RDynLib...       TRUE        NA         0
-  precScanNum precursorMz precursorIntensity precursorCharge collisionEnergy isolationWindowLowerMz
-    <integer>   <numeric>          <numeric>       <integer>       <numeric>              <numeric>
-1        3567     677.134         126397.703               2              35                     NA
-2        3568     707.100            883.993               0              35                     NA
-3        3568     647.160            807.771               0              35                     NA
-4        3569     545.130            321.628               0              35                     NA
-5        3569     484.480            116.030               0              35                     NA
-6        3569     545.130            321.628               0              35                     NA
-7        3565     596.070            553.066               0              35                     NA
-8        3506     729.090            535.596               0              35                     NA
-  isolationWindowTargetMz isolationWindowUpperMz peaksCount totIonCurrent basePeakMZ basePeakIntensity
-                <numeric>              <numeric>  <integer>     <numeric>  <numeric>         <numeric>
-1                      NA                     NA         33    5758.27579    707.095         883.99316
-2                      NA                     NA          6     475.90352    545.132         321.62772
-3                      NA                     NA          4     463.92892    484.929         314.61465
-4                      NA                     NA          3      73.31370    445.117          33.29948
-5                      NA                     NA          1       8.67285    301.050           8.67285
-6                      NA                     NA          3      73.31370    445.117          33.29948
-7                      NA                     NA         11     489.00798    485.227          95.01157
-8                      NA                     NA          4     124.09554    629.146          62.68373
-  ionisationEnergy     lowMZ    highMZ mergedScan mergedResultScanNum mergedResultStartScanNum
-         <numeric> <numeric> <numeric>  <integer>           <integer>                <integer>
-1                0   295.291  1015.097         NA                  NA                       NA
-2                0   299.205   563.556         NA                  NA                       NA
-3                0   305.069   484.929         NA                  NA                       NA
-4                0   254.943   445.117         NA                  NA                       NA
-5                0   301.050   301.050         NA                  NA                       NA
-6                0   254.943   445.117         NA                  NA                       NA
-7                0   216.861   869.306         NA                  NA                       NA
-8                0   427.205   711.211         NA                  NA                       NA
-  mergedResultEndScanNum injectionTime filterString    spectrumId ionMobilityDriftTime scanWindowLowerLimit
-               <integer>     <numeric>  <character>   <character>            <numeric>            <numeric>
-1                     NA             0           NA controller...                   NA              295.291
-2                     NA             0           NA controller...                   NA              299.205
-3                     NA             0           NA controller...                   NA              305.069
-4                     NA             0           NA controller...                   NA              254.943
-5                     NA             0           NA controller...                   NA              301.050
-6                     NA             0           NA controller...                   NA              254.943
-7                     NA             0           NA controller...                   NA              216.861
-8                     NA             0           NA controller...                   NA              427.205
-  scanWindowUpperLimit electronBeamEnergy chrom_peak_rt chrom_peak_mz chrom_peak_id feature_rtmed
-             <numeric>          <numeric>     <numeric>     <numeric>   <character>     <numeric>
-1             1015.097                 NA       2070.51       677.134       CP57620       2070.93
-2              563.556                 NA            NA            NA            NA            NA
-3              484.929                 NA            NA            NA            NA            NA
-4              445.117                 NA            NA            NA            NA            NA
-5              301.050                 NA            NA            NA            NA            NA
-6              445.117                 NA            NA            NA            NA            NA
-7              869.306                 NA            NA            NA            NA            NA
-8              711.211                 NA            NA            NA            NA            NA
-  feature_mzmed  feature_id rtime_adjusted MSntreeID precursorMz.MS2 precMzRound MergedMSntreeID
-      <numeric> <character>      <numeric> <numeric>       <numeric>   <numeric>       <integer>
-1       677.133      FT4198             NA      1559              NA         677             298
-2            NA      FT4198        2067.22      1559         677.134         707             298
-3            NA      FT4198        2067.54      1559         677.134         647             298
-4            NA      FT4198        2067.86      1559         677.134         545             298
-5            NA      FT4198        2068.19      1390         677.132         484             298
-6            NA      FT4198        2067.86      1559         677.134         545             298
-7            NA      FT4198        2065.87      1389         677.132         596             298
-8            NA      FT4198        2067.51      1189         677.130         729             298
+
 ## MS4 spectra from other `round(`precursor_mz_MS2)` 
 
 ## MS4 spectra from same `round(`precursor_mz_MS2)`, but different `round(precursorMz)`.


### PR DESCRIPTION
This new workflow for selecting a single best spectral tree works quite well, I found. Finally it seems to me there will be no need to use combineSpectra().
But I would like to add still MS3 and MS4 spectra, resulting from fragmentation of different MS2 or MS3 fragments, from other MSntreeID, to the selected spectral trees.