### PR TITLE
Small update of the centroiding qmd

### DIFF
--- a/centroiding.qmd
+++ b/centroiding.qmd
@@ -27,21 +27,24 @@ library(purrr)
 
 ```
 
-We use the *Spectra* package, in particular its `pickPeaks()` function to perform the centroiding. We perform the analysis separately for each original mzXML file and export the data directly to a file in mzML format.
+We use the *Spectra* package, in particular its `pickPeaks()` function to
+perform the centroiding. We perform the analysis separately for each original
+mzXML file and export the data directly to a file in mzML format.
 
 ```{r}
 #' Define the paths to the original mzXML files with the profile-mode data
 #' and the path where we want to export the centroided mzML data.
 pth <- getwd()
-MZXML_PATH <- file.path(pth,"data","mzXML")
-MZML_PATH <- file.path(pth,"data","mzML_cent1")
+MZXML_PATH <- file.path(pth, "data", "mzXML")
+MZML_PATH <- file.path(pth, "data", "mzML_cent1")
 
 #' List all files
 fls <- dir(MZXML_PATH, full.name = TRUE)
 
 ```
 
-We first inspect the profile-mode data and dry-run the centroiding on one spectrum.
+We first inspect the profile-mode data and dry-run the centroiding on one
+spectrum.
 
 ```{r}
 a <- filterMsLevel(Spectra(fls[1]), 1L)[4]
@@ -54,11 +57,17 @@ filterMzRange(a, c(372.5, 373.5)) |>
 grid()
 ```
 
-In profile-mode data, each mass peak is represented by a distribution of signal. The centroiding will select a single, representative, mass peak for each such distribution. The algorithm we apply first estimates local maxima in each MS1 spectrum and for each it reports the peak with the maximum intensity. We further *refine* the m/z of the reported mass peak using an intensity-weighted average of the mass peak and the neighboring 2 peaks (`k = 2L`), if their intensity is at least 1/3 (`threshold = 0.33`) of the reported mass peak.
+In profile-mode data, each mass peak is represented by a distribution of
+signal. The centroiding will select a single, representative, mass peak for each
+such distribution. The algorithm we apply first estimates local maxima in each
+MS1 spectrum and for each it reports the peak with the maximum intensity. We
+further *refine* the m/z of the reported mass peak using an intensity-weighted
+average of the mass peak and the neighboring 2 peaks (`k = 2L`), if their
+intensity is at least 1/3 (`threshold = 0.33`) of the reported mass peak.
 
 ```{r}
 
-a_c <-Spectra::pickPeaks(a, halfWindowSize = 10L, k = 2L, threshold = 0.33)
+a_c <- Spectra::pickPeaks(a, halfWindowSize = 10L, k = 2L, threshold = 0.33)
 
 par(mfrow = c(2, 2))
 plotSpectra(a)
@@ -86,7 +95,9 @@ filterMzRange(a_c, mz = c(200.15, 200.2)) |>
 grid()
 ```
 
-While we reduced the profile-mode peaks to single mass peaks there is still some remains of the fast fourier transform artefact present, especially for the first example.
+While we reduced the profile-mode peaks to single mass peaks there is still some
+remains of the fast fourier transform artefact present, especially for the first
+example.
 
 We proceed now and centroid all data files with the settings above.
 
@@ -95,23 +106,20 @@ if (!dir.exists(MZML_PATH))
     dir.create(MZML_PATH, recursive = TRUE)
 
 library(BiocParallel)
-bpparam <- MulticoreParam(workers = 4)  
+bpparam <- MulticoreParam(workers = 4)
 
 bplapply(fls, function(f) {
   message("Processing: ", basename(f))
   a <- Spectra(f)
   a <- setBackend(a, MsBackendMemory())
-  ms1 <- filterMsLevel(a, 1L)
-  msx <- filterMsLevel(a, 2:4)
-  ms1_cent <- Spectra::pickPeaks(ms1, halfWindowSize = 10L, k = 2L, threshold = 0.33)
-  ms1_cent <- applyProcessing(ms1_cent)
-  merged <- concatenateSpectra(list(ms1_cent, msx))
-  merged <- merged[order(rtime(merged))]
+  a <- Spectra::pickPeaks(a, halfWindowSize = 10L, k = 2L, threshold = 0.33,
+                          msLevel. = 1L)
   fn <- file.path(MZML_PATH, sub("\\.mzXML$", ".mzML", basename(f)))
-  export(merged, backend = MsBackendMzR(), file = fn, format = "mzML", copy = FALSE)
+  export(a, backend = MsBackendMzR(), file = fn, format = "mzML",
+         copy = FALSE)
 }, BPPARAM = bpparam)
 
-
+fn <- file.path(MZML_PATH, sub("\\.mzXML$", ".mzML", basename(fls[1L])))
 b <- Spectra(fn)
 msLevel(b) |> table()
 all(centroided(b))
@@ -120,16 +128,6 @@ all(centroided(b))
 all.equal(a$acquisitionNum, b$acquisitionNum)
 all.equal(a$precScanNum, b$precScanNum)
 all.equal(a$scanIndex, b$scanIndex)
-```
-
-```{r}
-
-```
-
-```         
-```
-
-```         
 ```
 
 # Questions and notes


### PR DESCRIPTION
I changed the splitting/merging of the `Spectra` by adding the parameter `msLevel. = 1L` to the `pickPeaks()` call - that way centroiding is **only** performed for the MS1 spectra.